### PR TITLE
fix: prometheus configMap issue for k3s

### DIFF
--- a/base/monitoring/prometheus/rbac/prometheus.ConfigMap.yaml
+++ b/base/monitoring/prometheus/rbac/prometheus.ConfigMap.yaml
@@ -7,6 +7,267 @@ metadata:
     app.kubernetes.io/component: prometheus
   name: prometheus-rbac
 data:
-  prometheus.yml: "global:\n  scrape_interval:     30s\n  evaluation_interval: 30s\n\nalerting:\n  alertmanagers:\n    # Bundled Alertmanager, started by prom-wrapper\n    - static_configs:\n        - targets: ['127.0.0.1:9093']\n      path_prefix: /alertmanager\n    # Uncomment the following to have alerts delivered to additional Alertmanagers discovered\n    # in the cluster. This configuration is not required if you use Sourcegraph's built-in alerting:\n    # https://docs.sourcegraph.com/admin/observability/alerting\n    # - kubernetes_sd_configs:\n    #  - role: endpoints\n    #  relabel_configs:\n    #    - source_labels: [__meta_kubernetes_service_name]\n    #      regex: alertmanager\n    #      action: keep\n\nrule_files:\n  - '*_rules.yml'\n  - \"/sg_config_prometheus/*_rules.yml\"\n  - \"/sg_prometheus_add_ons/*_rules.yml\"\n\n# A scrape configuration for running Prometheus on a Kubernetes cluster.\n# This uses separate scrape configs for cluster components (i.e. API server, node)\n# and services to allow each to use different authentication configs.\n#\n# Kubernetes labels will be added as Prometheus labels on metrics via the\n# `labelmap` relabeling action.\n\n# Scrape config for API servers.\n#\n# Kubernetes exposes API servers as endpoints to the default/kubernetes\n# service so this uses `endpoints` role and uses relabelling to only keep\n# the endpoints associated with the default/kubernetes service using the\n# default named port `https`. This works for single API server deployments as\n# well as HA API server deployments.\nscrape_configs:\n- job_name: 'kubernetes-apiservers'\n\n  kubernetes_sd_configs:\n  - role: endpoints\n\n  # Default to scraping over https. If required, just disable this or change to\n  # `http`.\n  scheme: https\n\n  # This TLS & bearer token file config is used to connect to the actual scrape\n  # endpoints for cluster components. This is separate to discovery auth\n  # configuration because discovery & scraping are two separate concerns in\n  # Prometheus. The discovery auth config is automatic if Prometheus runs inside\n  # the cluster. Otherwise, more config options have to be provided within the\n  # <kubernetes_sd_config>.\n  tls_config:\n    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n    # If your node certificates are self-signed or use a different CA to the\n    # master CA, then disable certificate verification below. Note that\n    # certificate verification is an integral part of a secure infrastructure\n    # so this should only be disabled in a controlled environment. You can\n    # disable certificate verification by uncommenting the line below.\n    #\n    # insecure_skip_verify: true\n  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token\n\n  # Keep only the default/kubernetes service endpoints for the https port. This\n  # will add targets for each API server which Kubernetes adds an endpoint to\n  # the default/kubernetes service.\n  relabel_configs:\n  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]\n    action: keep\n    regex: default;kubernetes;https\n\n- job_name: 'kubernetes-nodes'\n\n  # Default to scraping over https. If required, just disable this or change to\n  # `http`.\n  scheme: https\n\n  # This TLS & bearer token file config is used to connect to the actual scrape\n  # endpoints for cluster components. This is separate to discovery auth\n  # configuration because discovery & scraping are two separate concerns in\n  # Prometheus. The discovery auth config is automatic if Prometheus runs inside\n  # the cluster. Otherwise, more config options have to be provided within the\n  # <kubernetes_sd_config>.\n  tls_config:\n    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n    # If your node certificates are self-signed or use a different CA to the\n    # master CA, then disable certificate verification below. Note that\n    # certificate verification is an integral part of a secure infrastructure\n    # so this should only be disabled in a controlled environment. You can\n    # disable certificate verification by uncommenting the line below.\n    #\n    insecure_skip_verify: true\n  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token\n\n  kubernetes_sd_configs:\n  - role: node\n\n  relabel_configs:\n  - action: labelmap\n    regex: __meta_kubernetes_node_label_(.+)\n  - target_label: __address__\n    replacement: kubernetes.default.svc:443\n  - source_labels: [__meta_kubernetes_node_name]\n    regex: (.+)\n    target_label: __metrics_path__\n    replacement: /api/v1/nodes/${1}/proxy/metrics\n\n# Scrape config for service endpoints.\n#\n# The relabeling allows the actual service scrape endpoint to be configured\n# via the following annotations:\n#\n# * `sourcegraph.prometheus/scrape`: Only scrape services that have a value of `true`\n# * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need\n# to set this to `https` & most likely set the `tls_config` of the scrape config.\n# * `prometheus.io/path`: If the metrics path is not `/metrics` override this.\n# * `prometheus.io/port`: If the metrics are exposed on a different port to the\n# service then set this appropriately.\n- job_name: 'kubernetes-service-endpoints'\n\n  kubernetes_sd_configs:\n  - role: endpoints\n\n  relabel_configs:\n    # Sourcegraph specific customization, only scrape pods with our annotation\n  - source_labels: [__meta_kubernetes_service_annotation_sourcegraph_prometheus_scrape]\n    action: keep\n    regex: true\n  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]\n    action: replace\n    target_label: __scheme__\n    regex: (https?)\n  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]\n    action: replace\n    target_label: __metrics_path__\n    regex: (.+)\n  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]\n    action: replace\n    target_label: __address__\n    regex: (.+)(?::\\d+);(\\d+)\n    replacement: $1:$2\n  - action: labelmap\n    regex: __meta_kubernetes_service_label_(.+)\n  - source_labels: [__meta_kubernetes_namespace]\n    action: replace\n    # Sourcegraph specific customization. We want a more convenient to type label.\n    # target_label: kubernetes_namespace\n    target_label: ns\n  - source_labels: [__meta_kubernetes_service_name]\n    action: replace\n    target_label: kubernetes_name\n  # Sourcegraph specific customization. We want a nicer name for job\n  - source_labels: [app]\n    action: replace\n    target_label: job\n  # Sourcegraph specific customization. We want a nicer name for instance\n  - source_labels: [__meta_kubernetes_pod_name]\n    action: replace\n    target_label: instance\n  # Sourcegraph specific customization. We want to add a label to every \n  # metric that indicates the node it came from.\n  - source_labels: [__meta_kubernetes_endpoint_node_name]\n    action: replace\n    target_label: nodename\n  metric_relabel_configs:\n  # Sourcegraph specific customization. Drop metrics with empty nodename responses from the k8s API\n  - source_labels: [nodename]\n    regex: ^$\n    action: drop\n\n# Example scrape config for probing services via the Blackbox Exporter.\n#\n# The relabeling allows the actual service scrape endpoint to be configured\n# via the following annotations:\n#\n# * `prometheus.io/probe`: Only probe services that have a value of `true`\n- job_name: 'kubernetes-services'\n\n  metrics_path: /probe\n  params:\n    module: [http_2xx]\n\n  kubernetes_sd_configs:\n  - role: service\n\n  relabel_configs:\n  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]\n    action: keep\n    regex: true\n  - source_labels: [__address__]\n    target_label: __param_target\n  - target_label: __address__\n    replacement: blackbox\n  - source_labels: [__param_target]\n    target_label: instance\n  - action: labelmap\n    regex: __meta_kubernetes_service_label_(.+)\n  - source_labels: [__meta_kubernetes_service_namespace]\n    # Sourcegraph specific customization. We want a more convenient to type label.\n    # target_label: kubernetes_namespace\n    target_label: ns\n  - source_labels: [__meta_kubernetes_service_name]\n    target_label: kubernetes_name\n\n# Example scrape config for pods\n#\n# The relabeling allows the actual pod scrape endpoint to be configured via the\n# following annotations:\n#\n# * `sourcegraph.prometheus/scrape`: Only scrape pods that have a value of `true`\n# * `prometheus.io/path`: If the metrics path is not `/metrics` override this.\n# * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.\n- job_name: 'kubernetes-pods'\n\n  kubernetes_sd_configs:\n  - role: pod\n\n  relabel_configs:\n    # Sourcegraph specific customization, only scrape pods with our annotation\n  - source_labels: [__meta_kubernetes_pod_annotation_sourcegraph_prometheus_scrape]\n    action: keep\n    regex: true\n  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]\n    action: replace\n    target_label: __metrics_path__\n    regex: (.+)\n  - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]\n    action: replace\n    regex: (.+):(?:\\d+);(\\d+)\n    replacement: ${1}:${2}\n    target_label: __address__\n  - action: labelmap\n    regex: __meta_kubernetes_pod_label_(.+)\n  - source_labels: [__meta_kubernetes_pod_name]\n    action: replace\n    target_label: kubernetes_pod_name\n  # Sourcegraph specific customization. We want a more convenient to type label.\n  # target_label: kubernetes_namespace\n  - source_labels: [__meta_kubernetes_namespace]\n    action: replace\n    target_label: ns\n  # Sourcegraph specific customization. We want to add a label to every \n  # metric that indicates the node it came from.\n  - source_labels: [__meta_kubernetes_pod_node_name]\n    action: replace\n    target_label: nodename\n\n  metric_relabel_configs:\n  # cAdvisor-specific customization. Drop container metrics exported by cAdvisor\n  # not in the same namespace as Sourcegraph.\n  # Uncomment this if you have problems with certain dashboards or cAdvisor itself\n  # picking up non-Sourcegraph services. Ensure all Sourcegraph services are running\n  # within the Sourcegraph namespace you have defined.\n  # The regex must keep matches on '^$' (empty string) to ensure other metrics do not\n  # get dropped.\n  # - source_labels: [container_label_io_kubernetes_pod_namespace]\n  #   regex: ^$|ns-sourcegraph # ensure this matches with namespace declarations\n  #   action: keep\n  - source_labels: [container_label_io_kubernetes_pod_namespace]\n    regex: kube-system\n    action: drop\n  # cAdvisor-specific customization. We want container metrics to be named after their container name label.\n  # Note that 'io.kubernetes.container.name' and 'io.kubernetes.pod.name' must be provided in cAdvisor\n  # '--whitelisted_container_labels' (see cadvisor.DaemonSet.yaml)\n  - source_labels: [container_label_io_kubernetes_container_name, container_label_io_kubernetes_pod_name]\n    regex: (.+)\n    action: replace\n    target_label: name\n    separator: '-'\n  # Sourcegraph specific customization. Drop metrics with empty nodename responses from the k8s API\n  - source_labels: [nodename]\n    regex: ^$\n    action: drop\n\n# Scrape prometheus itself for metrics.\n- job_name: 'builtin-prometheus'\n  static_configs:\n    - targets: ['127.0.0.1:9092']\n      labels:\n        app: prometheus\n- job_name: 'builtin-alertmanager'\n  metrics_path: /alertmanager/metrics\n  static_configs:\n    - targets: ['127.0.0.1:9093']\n      labels:\n        app: alertmanager\n"
+  prometheus.yml: |
+    global:
+      scrape_interval:     30s
+      evaluation_interval: 30s
+    alerting:
+      alertmanagers:
+        # Bundled Alertmanager, started by prom-wrapper
+        - static_configs:
+            - targets: ['127.0.0.1:9093']
+          path_prefix: /alertmanager
+        # Uncomment the following to have alerts delivered to additional Alertmanagers discovered
+        # in the cluster. This configuration is not required if you use Sourcegraph's built-in alerting:
+        # https://docs.sourcegraph.com/admin/observability/alerting
+        # - kubernetes_sd_configs:
+        #  - role: endpoints
+        #  relabel_configs:
+        #    - source_labels: [__meta_kubernetes_service_name]
+        #      regex: alertmanager
+        #      action: keep
+    rule_files:
+      - '*_rules.yml'
+      - "/sg_config_prometheus/*_rules.yml"
+      - "/sg_prometheus_add_ons/*_rules.yml"
+    # A scrape configuration for running Prometheus on a Kubernetes cluster.
+    # This uses separate scrape configs for cluster components (i.e. API server, node)
+    # and services to allow each to use different authentication configs.
+    #
+    # Kubernetes labels will be added as Prometheus labels on metrics via the
+    # `labelmap` relabeling action.
+    # Scrape config for API servers.
+    #
+    # Kubernetes exposes API servers as endpoints to the default/kubernetes
+    # service so this uses `endpoints` role and uses relabelling to only keep
+    # the endpoints associated with the default/kubernetes service using the
+    # default named port `https`. This works for single API server deployments as
+    # well as HA API server deployments.
+    scrape_configs:
+    - job_name: 'kubernetes-apiservers'
+      kubernetes_sd_configs:
+      - role: endpoints
+      # Default to scraping over https. If required, just disable this or change to
+      # `http`.
+      scheme: https
+      # This TLS & bearer token file config is used to connect to the actual scrape
+      # endpoints for cluster components. This is separate to discovery auth
+      # configuration because discovery & scraping are two separate concerns in
+      # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+      # the cluster. Otherwise, more config options have to be provided within the
+      # <kubernetes_sd_config>.
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        # If your node certificates are self-signed or use a different CA to the
+        # master CA, then disable certificate verification below. Note that
+        # certificate verification is an integral part of a secure infrastructure
+        # so this should only be disabled in a controlled environment. You can
+        # disable certificate verification by uncommenting the line below.
+        #
+        # insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      # Keep only the default/kubernetes service endpoints for the https port. This
+      # will add targets for each API server which Kubernetes adds an endpoint to
+      # the default/kubernetes service.
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: default;kubernetes;https
+    - job_name: 'kubernetes-nodes'
+      # Default to scraping over https. If required, just disable this or change to
+      # `http`.
+      scheme: https
+      # This TLS & bearer token file config is used to connect to the actual scrape
+      # endpoints for cluster components. This is separate to discovery auth
+      # configuration because discovery & scraping are two separate concerns in
+      # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+      # the cluster. Otherwise, more config options have to be provided within the
+      # <kubernetes_sd_config>.
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        # If your node certificates are self-signed or use a different CA to the
+        # master CA, then disable certificate verification below. Note that
+        # certificate verification is an integral part of a secure infrastructure
+        # so this should only be disabled in a controlled environment. You can
+        # disable certificate verification by uncommenting the line below.
+        #
+        insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+    # Scrape config for service endpoints.
+    #
+    # The relabeling allows the actual service scrape endpoint to be configured
+    # via the following annotations:
+    #
+    # * `sourcegraph.prometheus/scrape`: Only scrape services that have a value of `true`
+    # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
+    # to set this to `https` & most likely set the `tls_config` of the scrape config.
+    # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+    # * `prometheus.io/port`: If the metrics are exposed on a different port to the
+    # service then set this appropriately.
+    - job_name: 'kubernetes-service-endpoints'
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+        # Sourcegraph specific customization, only scrape pods with our annotation
+      - source_labels: [__meta_kubernetes_service_annotation_sourcegraph_prometheus_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+        action: replace
+        target_label: __scheme__
+        regex: (https?)
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+        action: replace
+        target_label: __address__
+        regex: (.+)(?::\d+);(\d+)
+        replacement: $1:$2
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        # Sourcegraph specific customization. We want a more convenient to type label.
+        # target_label: kubernetes_namespace
+        target_label: ns
+      - source_labels: [__meta_kubernetes_service_name]
+        action: replace
+        target_label: kubernetes_name
+      # Sourcegraph specific customization. We want a nicer name for job
+      - source_labels: [app]
+        action: replace
+        target_label: job
+      # Sourcegraph specific customization. We want a nicer name for instance
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: instance
+      # Sourcegraph specific customization. We want to add a label to every 
+      # metric that indicates the node it came from.
+      - source_labels: [__meta_kubernetes_endpoint_node_name]
+        action: replace
+        target_label: nodename
+      metric_relabel_configs:
+      # Sourcegraph specific customization. Drop metrics with empty nodename responses from the k8s API
+      - source_labels: [nodename]
+        regex: ^$
+        action: drop
+    # Example scrape config for probing services via the Blackbox Exporter.
+    #
+    # The relabeling allows the actual service scrape endpoint to be configured
+    # via the following annotations:
+    #
+    # * `prometheus.io/probe`: Only probe services that have a value of `true`
+    - job_name: 'kubernetes-services'
+      metrics_path: /probe
+      params:
+        module: [http_2xx]
+      kubernetes_sd_configs:
+      - role: service
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
+        action: keep
+        regex: true
+      - source_labels: [__address__]
+        target_label: __param_target
+      - target_label: __address__
+        replacement: blackbox
+      - source_labels: [__param_target]
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [__meta_kubernetes_service_namespace]
+        # Sourcegraph specific customization. We want a more convenient to type label.
+        # target_label: kubernetes_namespace
+        target_label: ns
+      - source_labels: [__meta_kubernetes_service_name]
+        target_label: kubernetes_name
+    # Example scrape config for pods
+    #
+    # The relabeling allows the actual pod scrape endpoint to be configured via the
+    # following annotations:
+    #
+    # * `sourcegraph.prometheus/scrape`: Only scrape pods that have a value of `true`
+    # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+    # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
+    - job_name: 'kubernetes-pods'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+        # Sourcegraph specific customization, only scrape pods with our annotation
+      - source_labels: [__meta_kubernetes_pod_annotation_sourcegraph_prometheus_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: (.+):(?:\d+);(\d+)
+        replacement: ${1}:${2}
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+      # Sourcegraph specific customization. We want a more convenient to type label.
+      # target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: ns
+      # Sourcegraph specific customization. We want to add a label to every 
+      # metric that indicates the node it came from.
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: nodename
+      metric_relabel_configs:
+      # cAdvisor-specific customization. Drop container metrics exported by cAdvisor
+      # not in the same namespace as Sourcegraph.
+      # Uncomment this if you have problems with certain dashboards or cAdvisor itself
+      # picking up non-Sourcegraph services. Ensure all Sourcegraph services are running
+      # within the Sourcegraph namespace you have defined.
+      # The regex must keep matches on '^$' (empty string) to ensure other metrics do not
+      # get dropped.
+      # - source_labels: [container_label_io_kubernetes_pod_namespace]
+      #   regex: ^$|ns-sourcegraph # ensure this matches with namespace declarations
+      #   action: keep
+      # cAdvisor-specific customization. We want container metrics to be named after their container name label.
+      # Note that 'io.kubernetes.container.name' and 'io.kubernetes.pod.name' must be provided in cAdvisor
+      # '--whitelisted_container_labels' (see cadvisor.DaemonSet.yaml)
+      - source_labels: [container_label_io_kubernetes_container_name, container_label_io_kubernetes_pod_name]
+        regex: (.+)
+        action: replace
+        target_label: name
+        separator: '-'
+      # Sourcegraph specific customization. Drop metrics with empty nodename responses from the k8s API
+      - source_labels: [nodename]
+        regex: ^$
+        action: drop
+    # Scrape prometheus itself for metrics.
+    - job_name: 'builtin-prometheus'
+      static_configs:
+        - targets: ['127.0.0.1:9092']
+          labels:
+            app: prometheus
+    - job_name: 'builtin-alertmanager'
+      metrics_path: /alertmanager/metrics
+      static_configs:
+        - targets: ['127.0.0.1:9093']
+          labels:
+            app: alertmanager
   extra_rules.yml: ""
   prometheus_targets.yml: ""

--- a/components/clusters/k3s/monitoring/patches/prometheus.ConfigMap.yaml
+++ b/components/clusters/k3s/monitoring/patches/prometheus.ConfigMap.yaml
@@ -159,13 +159,10 @@ data:
         target_label: ns
       metric_relabel_configs:
       - source_labels: [kubernetes_io_hostname]
-        regex: sourcegraph-0
+        regex: sourcegraph-0 # ACTION: replace 'sourcegraph-0' with your node name
         action: keep
       - source_labels: [namespace]
-        regex: default
-        action: keep
-      - source_labels: [container_label_io_kubernetes_pod_namespace]
-        regex: ^$|default # ACTION: replace default with your namespace
+        regex: default # ACTION: replace 'default' with your namespace
         action: keep
       ############################################################################################################
 

--- a/components/clusters/k3s/monitoring/patches/prometheus.ConfigMap.yaml
+++ b/components/clusters/k3s/monitoring/patches/prometheus.ConfigMap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus
+  name: prometheus-rbac
 data:
   prometheus.yml: |
     global:
@@ -28,6 +28,7 @@ data:
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name, __meta_kubernetes_pod_node_name]
         action: keep
         regex: default;kubernetes;https
+
     - job_name: 'kubernetes-nodes'
       scheme: https
       tls_config:
@@ -65,8 +66,9 @@ data:
         regex: (.+)
         action: replace
         target_label: container_label_io_kubernetes_pod_name
+
     ############################################################################################################
-    
+
     - job_name: 'kubernetes-service-endpoints'
       kubernetes_sd_configs:
       - role: endpoints
@@ -126,6 +128,7 @@ data:
         target_label: ns
       - source_labels: [__meta_kubernetes_service_name]
         target_label: kubernetes_name
+
     - job_name: 'kubernetes-pods'
       kubernetes_sd_configs:
       - role: pod
@@ -161,7 +164,11 @@ data:
       - source_labels: [namespace]
         regex: default
         action: keep
+      - source_labels: [container_label_io_kubernetes_pod_namespace]
+        regex: ^$|default # ACTION: replace default with your namespace
+        action: keep
       ############################################################################################################
+
     # Scrape prometheus itself for metrics.
     - job_name: 'builtin-prometheus'
       static_configs:

--- a/examples/k3s/kustomization.yaml
+++ b/examples/k3s/kustomization.yaml
@@ -1,11 +1,12 @@
 # Includes RBAC resources
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: default
+namespace: ns-sourcegraph
 resources:
   # Sourcegraph Main Stack
   - ../../base/sourcegraph
 components:
+  - ../../components/resources/namespace
   # Use resources for a size-XS instance
   - ../../components/sizes/xs
   # This configures the Sourcegraph instance and networking to work in a k3s cluster

--- a/examples/k3s/kustomization.yaml
+++ b/examples/k3s/kustomization.yaml
@@ -1,6 +1,7 @@
 # Includes RBAC resources
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: default
 resources:
   # Sourcegraph Main Stack
   - ../../base/sourcegraph

--- a/examples/k3s/l/kustomization.yaml
+++ b/examples/k3s/l/kustomization.yaml
@@ -1,6 +1,7 @@
 # Includes RBAC resources
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: default
 resources:
   # Sourcegraph Main Stack
   - ../../../base/sourcegraph

--- a/examples/k3s/m/kustomization.yaml
+++ b/examples/k3s/m/kustomization.yaml
@@ -1,6 +1,7 @@
 # Includes RBAC resources
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: default
 resources:
   # Sourcegraph Main Stack
   - ../../../base/sourcegraph

--- a/examples/k3s/s/kustomization.yaml
+++ b/examples/k3s/s/kustomization.yaml
@@ -1,6 +1,7 @@
 # Includes RBAC resources
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: default
 resources:
   # Sourcegraph Main Stack
   - ../../../base/sourcegraph

--- a/examples/k3s/xl/kustomization.yaml
+++ b/examples/k3s/xl/kustomization.yaml
@@ -1,6 +1,7 @@
 # Includes RBAC resources
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: default
 resources:
   # Sourcegraph Main Stack
   - ../../../base/sourcegraph

--- a/examples/k3s/xs/kustomization.yaml
+++ b/examples/k3s/xs/kustomization.yaml
@@ -1,6 +1,7 @@
 # Includes RBAC resources
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: default
 resources:
   # Sourcegraph Main Stack
   - ../../../base/sourcegraph


### PR DESCRIPTION
## Description

<!-- description here -->

Update k3s to use configMap with privileged settings.

Also added the default namespace to k3s overlays

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Deployed into a multi-nodes k3s cluster with metrics showing up:

![image](https://user-images.githubusercontent.com/68532117/221055615-80778b5f-005d-48c3-b542-3cb6559f7a94.png)
![image](https://user-images.githubusercontent.com/68532117/221055631-1ab625a9-7dea-4880-8c9c-9e78a9e2153a.png)

```
NAME            STATUS   ROLES                  AGE   VERSION
sourcegraph-1   Ready    <none>                 11m   v1.25.6+k3s1
sourcegraph-0   Ready    control-plane,master   41m   v1.25.6+k3s1
```


```
default       github-proxy-5565f68966-t8rws                1/1     Running     0               8m51s
default       cadvisor-6p9gm                               1/1     Running     0               8m51s
default       node-exporter-78ztn                          1/1     Running     0               8m51s
default       cadvisor-wbbsv                               1/1     Running     0               8m51s
default       node-exporter-2fqxn                          1/1     Running     0               8m51s
default       syntect-server-5d86c8bbc9-jmn4j              1/1     Running     0               8m51s
default       prometheus-55c74946fd-xq7nw                  1/1     Running     0               8m51s
default       blobstore-7c565469b8-7x5rc                   1/1     Running     0               8m51s
default       codeinsights-db-0                            2/2     Running     0               8m51s
default       redis-cache-7cdf774f8-2pqzt                  2/2     Running     0               8m51s
default       grafana-0                                    1/1     Running     0               8m51s
default       codeintel-db-0                               2/2     Running     0               8m51s
default       indexed-search-0                             2/2     Running     0               8m51s
default       redis-store-54488d96f7-8m9n8                 2/2     Running     0               8m51s
default       pgsql-0                                      2/2     Running     0               8m51s
default       sourcegraph-frontend-dc4f45f55-l68pn         1/1     Running     0               8m50s
default       sourcegraph-frontend-dc4f45f55-snphq         1/1     Running     0               8m51s
default       gitserver-0                                  1/1     Running     2 (7m27s ago)   8m51s
default       searcher-0                                   1/1     Running     0               8m50s
default       precise-code-intel-worker-5f58bb6685-g4s9p   1/1     Running     0               8m51s
default       symbols-0                                    1/1     Running     0               8m50s
default       repo-updater-8bbccd46-676qv                  1/1     Running     0               8m51s
default       worker-8699887d49-mrj9c                      1/1     Running     0               8m50s
staging       cadvisor-sh5fb                               1/1     Running     0               116s
staging       node-exporter-8jnvb                          1/1     Running     0               116s
staging       node-exporter-pkwqj                          1/1     Running     0               116s
staging       cadvisor-2gvhz                               1/1     Running     0               116s
staging       github-proxy-5565f68966-vdqdn                1/1     Running     0               116s
staging       syntect-server-5d86c8bbc9-p6sbn              1/1     Running     0               115s
staging       prometheus-55c74946fd-knjvn                  1/1     Running     0               116s
staging       blobstore-558c9d5fb8-wknzg                   1/1     Running     0               116s
staging       redis-store-5997969f6d-vjzth                 2/2     Running     0               116s
staging       codeinsights-db-0                            2/2     Running     0               116s
staging       redis-cache-7889dc7768-6qw9w                 2/2     Running     0               116s
staging       grafana-0                                    1/1     Running     0               116s
staging       indexed-search-0                             2/2     Running     0               116s
staging       codeintel-db-0                               2/2     Running     0               116s
staging       pgsql-0                                      2/2     Running     0               116s
staging       sourcegraph-frontend-dc4f45f55-2v5nl         1/1     Running     0               116s
staging       sourcegraph-frontend-dc4f45f55-j9xlp         1/1     Running     0               115s
staging       gitserver-0                                  1/1     Running     2 (32s ago)     116s
staging       searcher-0                                   1/1     Running     0               115s
staging       precise-code-intel-worker-b5fd66897-k7wh6    1/1     Running     0               116s
staging       repo-updater-fcddc569-v8klw                  1/1     Running     0               116s
staging       symbols-0                                    1/1     Running     0               115s
staging       worker-8699887d49-22z2k                      1/1     Running     0               115s
```