### PR TITLE
update: set default deployType to Kustomize

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@
 
 - [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
 - [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
+- [ ] Kustomiz-specific changes
 - [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-docker)
 - [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
 - [ ] Verify all images have a valid tag and SHA256 sum

--- a/base/monitoring/prometheus/prometheus.yml
+++ b/base/monitoring/prometheus/prometheus.yml
@@ -43,7 +43,11 @@ scrape_configs: # Configure targets to scrape
       - source_labels: [container_label_io_kubernetes_pod_namespace]
         regex: kube-system
         action: drop
-      - source_labels: [container_label_io_kubernetes_container_name, container_label_io_kubernetes_pod_name]
+      - source_labels:
+          [
+            container_label_io_kubernetes_container_name,
+            container_label_io_kubernetes_pod_name,
+          ]
         regex: (.+)
         action: replace
         target_label: name
@@ -124,8 +128,12 @@ scrape_configs: # Configure targets to scrape
     relabel_configs:
       - source_labels: [__address__]
         target_label: instance
-        regex: (.*)\.(.*)
-        replacement: ${1}_${2}
+        regex: (.*)\:(.*)
+        replacement: ${1}
+      - source_labels: [__address__]
+        target_label: job
+        regex: (.*)\:(.*)
+        replacement: ${1}
       - source_labels: [container_label_io_kubernetes_pod_namespace]
         action: replace
         target_label: ns
@@ -138,7 +146,7 @@ scrape_configs: # Configure targets to scrape
         action: drop
     static_configs:
       - labels:
-          job: sourcegraph-service
+          group: sourcegraph-service
         targets:
           - sourcegraph-frontend:6060
           - github-proxy:6060

--- a/base/sourcegraph/frontend/sourcegraph-frontend.ConfigMap.yaml
+++ b/base/sourcegraph/frontend/sourcegraph-frontend.ConfigMap.yaml
@@ -8,7 +8,7 @@ metadata:
     sourcegraph-resource-requires: no-cluster-admin
   name: sourcegraph-frontend-env
 data:
-  DEPLOY_TYPE: kustomize
+  DEPLOY_TYPE: Kustomize
   PGDATABASE: sg
   PGHOST: pgsql
   PGPORT: "5432"

--- a/base/sourcegraph/frontend/sourcegraph-frontend.ConfigMap.yaml
+++ b/base/sourcegraph/frontend/sourcegraph-frontend.ConfigMap.yaml
@@ -8,7 +8,7 @@ metadata:
     sourcegraph-resource-requires: no-cluster-admin
   name: sourcegraph-frontend-env
 data:
-  DEPLOY_TYPE: Kustomize
+  DEPLOY_TYPE: kustomize
   PGDATABASE: sg
   PGHOST: pgsql
   PGPORT: "5432"

--- a/base/sourcegraph/frontend/sourcegraph-frontend.ConfigMap.yaml
+++ b/base/sourcegraph/frontend/sourcegraph-frontend.ConfigMap.yaml
@@ -8,7 +8,7 @@ metadata:
     sourcegraph-resource-requires: no-cluster-admin
   name: sourcegraph-frontend-env
 data:
-  DEPLOY_TYPE: kubernetes
+  DEPLOY_TYPE: kustomize
   PGDATABASE: sg
   PGHOST: pgsql
   PGPORT: "5432"

--- a/components/custom/old-patches/kustomization.yaml
+++ b/components/custom/old-patches/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patchesStrategicMerge:
+  -

--- a/components/services/searcher/deployment/kustomization.yaml
+++ b/components/services/searcher/deployment/kustomization.yaml
@@ -7,3 +7,9 @@ patches:
     target:
       kind: StatefulSet
       name: searcher
+  - patch: |-
+      - op: remove
+        path: /spec/clusterIP
+    target:
+      kind: Service
+      name: searcher

--- a/components/services/searcher/deployment/patches/searcher.Deployment.yaml
+++ b/components/services/searcher/deployment/patches/searcher.Deployment.yaml
@@ -8,7 +8,7 @@ spec:
       maxSurge: 1
       maxUnavailable: 1
     type: RollingUpdate
-  replica: 2
+  replicas: 2
   template:
     spec:
       containers:
@@ -56,4 +56,4 @@ spec:
   updateStrategy:
     $patch: delete
   volumeClaimTemplates:
-  serviceName:
+  serviceName: null

--- a/components/services/symbols/deployment/kustomization.yaml
+++ b/components/services/symbols/deployment/kustomization.yaml
@@ -7,3 +7,9 @@ patches:
     target:
       kind: StatefulSet
       name: symbols
+  - patch: |-
+      - op: remove
+        path: /spec/clusterIP
+    target:
+      kind: Service
+      name: symbols

--- a/components/services/symbols/deployment/patches/symbols.Deployment.yaml
+++ b/components/services/symbols/deployment/patches/symbols.Deployment.yaml
@@ -57,4 +57,4 @@ spec:
   updateStrategy:
     $patch: delete
   volumeClaimTemplates:
-  serviceName:
+  serviceName: null

--- a/components/utils/migrate-to-nonprivileged/kustomization.yaml
+++ b/components/utils/migrate-to-nonprivileged/kustomization.yaml
@@ -1,18 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 replacements:
-- path: images-update.yaml
+  - path: images-update.yaml
 patches:
-- path: searcher/searcher.Deployment.yaml
-  target:
-    group: apps
-    kind: StatefulSet|Deployment
-    name: searcher
-    version: v1
-- path: gitserver/gitserver.StatefulSet.yaml
-- path: grafana/grafana.StatefulSet.yaml
-- path: blobstore/blobstore.Deployment.yaml
-- path: indexed-search/indexed-search.StatefulSet.yaml
-- path: prometheus/prometheus.Deployment.yaml
-- path: redis/redis-cache.Deployment.yaml
-- path: redis/redis-store.Deployment.yaml
+  - path: searcher/searcher.Deployment.yaml
+    target:
+      group: apps
+      kind: StatefulSet|Deployment
+      name: searcher
+      version: v1
+  - path: gitserver/gitserver.StatefulSet.yaml
+  - path: grafana/grafana.StatefulSet.yaml
+  - path: blobstore/blobstore.Deployment.yaml
+  - path: indexed-search/indexed-search.StatefulSet.yaml
+  - path: prometheus/prometheus.Deployment.yaml
+  - path: redis/redis-cache.Deployment.yaml
+  - path: redis/redis-store.Deployment.yaml

--- a/instances/template/kustomization.template.yaml
+++ b/instances/template/kustomization.template.yaml
@@ -148,6 +148,12 @@ components:
   # - ../../components/utils/migrate-to-nonprivileged # -- Component for migrating from privileged to non-privileged
   #
   #---------------------------------------------------------------------------------------
+  # Resource migration from deploy-sourcegraph
+  #---------------------------------------------------------------------------------------
+  # - ../../components/clusters/old-base # -- Generate old cluster from deploy-sourcegraph
+  # - old-patches # -- Component to store patches from old deployment. See migration docs for more information
+  #
+  #---------------------------------------------------------------------------------------
   # Use private registry
   #---------------------------------------------------------------------------------------
   # - ../../components/enable/private-registry # -- Update images name to private registry name


### PR DESCRIPTION
## Description

set default deployType to Kustomize

Include minor components touch up

<!-- description here -->

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum
- [x] Kustomiz-specific

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Tested deployment with changes included in this PR:

```yaml
❯ k get pods -A
NAMESPACE     NAME                                             READY   STATUS    RESTARTS      AGE
default       blobstore-554b48dfb8-74hfg                       1/1     Running   0             19m
default       codeinsights-db-0                                2/2     Running   0             19m
default       codeintel-db-0                                   2/2     Running   1 (16m ago)   19m
default       github-proxy-699bdf7d88-2qqpc                    1/1     Running   0             19m
default       gitserver-0                                      1/1     Running   0             5m17s
default       grafana-0                                        1/1     Running   0             19m
default       indexed-search-0                                 2/2     Running   0             19m
default       node-exporter-7qd6z                              1/1     Running   0             41m
default       node-exporter-sbv97                              1/1     Running   0             41m
default       node-exporter-z9wmp                              1/1     Running   0             41m
default       pgsql-0                                          2/2     Running   0             19m
default       precise-code-intel-worker-5d7987f59-q622r        1/1     Running   0             19m
default       prometheus-69fc6fcc65-r2ksq                      1/1     Running   0             19m
default       redis-cache-64d97fcdd9-szp5b                     2/2     Running   0             19m
default       redis-store-f695c85cf-rhflf                      2/2     Running   0             19m
default       repo-updater-5464d58c7c-q7k5d                    1/1     Running   0             19m
default       searcher-0                                       1/1     Running   0             19m
default       sourcegraph-frontend-567cf7bfd-p5ldc             1/1     Running   0             19m
default       symbols-0                                        1/1     Running   0             19m
default       syntect-server-694b8f9fdc-g94mj                  1/1     Running   0             19m
default       worker-69b67b7b8c-lltgr                          1/1     Running   0             19m
```
