### PR TITLE
Update to Go 1.19.8

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.19.7
+golang 1.19.8
 yarn 1.22.4
 kubectl 1.21.7
 fd 7.4.0


### PR DESCRIPTION
Update to 1.19.8 because it fixes multiple vulnerabilities.

[_Created by Sourcegraph batch change `evict/update-to-go1.19.8`._](https://sourcegraph.sourcegraph.com/users/evict/batch-changes/update-to-go1.19.8)

## Test plan 
Local tests