### PR TITLE
Embeddings Service

### DIFF
--- a/base/monitoring/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/monitoring/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
         - name: cadvisor
-          image: index.docker.io/sourcegraph/cadvisor:4.5.1@sha256:9da386528adbdf755f38dab6a40f6c4dbbb489ea4c418b2412d1418b5b25d5ea
+          image: index.docker.io/sourcegraph/cadvisor:216430_2023-05-02_5.0-3cc9006de32c@sha256:6ea7f53807e4a559ee825ba2a0c4c3b3f721275f0b5ce0e979f4fdad8a4e478a
           args:
             # Kubernetes-specific flags below (other flags are baked into the Docker image)
             #

--- a/base/monitoring/grafana/grafana.StatefulSet.yaml
+++ b/base/monitoring/grafana/grafana.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: index.docker.io/sourcegraph/grafana:4.5.1@sha256:a04ca50bd1678dd0e15a72d77887c2bdd84b70358acb66d430fa0c2fb74e0399
+          image: index.docker.io/sourcegraph/grafana:216430_2023-05-02_5.0-3cc9006de32c@sha256:63baeadda6d33195ccd7d742670e500a80bacace3ed5cf0eb7d3a6c276ef7c34
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 3370

--- a/base/monitoring/jaeger/jaeger.Deployment.yaml
+++ b/base/monitoring/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:4.5.1@sha256:2f27f6069540d7db46a6a2e72d489802c1dff2081e4f4a94762f63b9147879f8
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:216430_2023-05-02_5.0-3cc9006de32c@sha256:ec73cff6ea398d96241a9451634fc83682292b0175cc63c09f1f866cf03beb8d
           args: ["--memory.max-traces=20000"]
           ports:
             - containerPort: 5775

--- a/base/monitoring/node-exporter/node-exporter.DaemonSet.yaml
+++ b/base/monitoring/node-exporter/node-exporter.DaemonSet.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: node-exporter
-          image: index.docker.io/sourcegraph/node-exporter:4.5.1@sha256:fa8e5700b7762fffe0674e944762f44bb787a7e44d97569fe55348260453bf80
+          image: index.docker.io/sourcegraph/node-exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:fa8e5700b7762fffe0674e944762f44bb787a7e44d97569fe55348260453bf80
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/base/monitoring/otel-collector/otel-agent.DaemonSet.yaml
+++ b/base/monitoring/otel-collector/otel-agent.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: otel-agent
-          image: index.docker.io/sourcegraph/opentelemetry-collector:4.5.1@sha256:647b6d3f12788eaf0f1708c5307bcd86804748972ad31ef857bbc189cffac342
+          image: index.docker.io/sourcegraph/opentelemetry-collector:216430_2023-05-02_5.0-3cc9006de32c@sha256:7783e0a2676813f955f45debc10099ee97e104c42fe27cd315848ba58de86cd4
           command:
             - "/bin/otelcol-sourcegraph"
             - "--config=/etc/otel-agent/config.yaml"

--- a/base/monitoring/otel-collector/otel-collector.Deployment.yaml
+++ b/base/monitoring/otel-collector/otel-collector.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: otel-collector
-          image: index.docker.io/sourcegraph/opentelemetry-collector:4.5.1@sha256:647b6d3f12788eaf0f1708c5307bcd86804748972ad31ef857bbc189cffac342
+          image: index.docker.io/sourcegraph/opentelemetry-collector:216430_2023-05-02_5.0-3cc9006de32c@sha256:7783e0a2676813f955f45debc10099ee97e104c42fe27cd315848ba58de86cd4
           command:
             - "/bin/otelcol-sourcegraph"
             # To use a custom configuration, edit otel-collector.ConfigMap.yaml

--- a/base/monitoring/prometheus/prometheus.Deployment.yaml
+++ b/base/monitoring/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: index.docker.io/sourcegraph/prometheus:4.5.1@sha256:e27296dc04bec4e4c1cc2d434c0b49d026a60f53b8907d1325ee1de42693abd3
+          image: index.docker.io/sourcegraph/prometheus:216430_2023-05-02_5.0-3cc9006de32c@sha256:da67ba5c797a7b7752cebd6507e903a2726c172c01cab7ce0e7deadff288bab8
           terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: SG_NAMESPACE

--- a/base/sourcegraph/blobstore/blobstore.Deployment.yaml
+++ b/base/sourcegraph/blobstore/blobstore.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: blobstore
-          image: index.docker.io/sourcegraph/blobstore:4.5.1@sha256:ba6db04892fe344a8767f0a8c375e29fce382b022a3f733eae2acd87f57404d3
+          image: index.docker.io/sourcegraph/blobstore:216430_2023-05-02_5.0-3cc9006de32c@sha256:ae1cf541f65441809f3495c037af4f9df1d049defdf0309a65d685f579c7e594
           livenessProbe:
             httpGet:
               path: /

--- a/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       initContainers:
         - name: correct-data-dir-permissions
-          image: index.docker.io/sourcegraph/alpine-3.14:4.5.1@sha256:03d0a2ae53bc45b288bc36c820b39596f858296875f93d971a45efbfe86fe014
+          image: index.docker.io/sourcegraph/alpine-3.14:216430_2023-05-02_5.0-3cc9006de32c@sha256:923c803fb975e905424b347e19839ae0077c0dec6eea0cb71c62acd910e8e9c8
           command: ["sh", "-c", "if [ -d /var/lib/postgresql/data/pgdata ]; then chmod 750 /var/lib/postgresql/data/pgdata; fi"]
           volumeMounts:
             - mountPath: /var/lib/postgresql/data/
@@ -45,7 +45,7 @@ spec:
             runAsUser: 70
       containers:
         - name: codeinsights
-          image: index.docker.io/sourcegraph/codeinsights-db:4.5.1@sha256:6ac520e96fedbb34456d086ca02591e6f40325668c98345308f1c700557b91fe
+          image: index.docker.io/sourcegraph/codeinsights-db:216430_2023-05-02_5.0-3cc9006de32c@sha256:910e98d4ddb6e5fef28be69f6395e567bbfab3f29f9d340dcdf45e83ca84cdd3
           env:
             - name: POSTGRES_DB
               value: postgres
@@ -82,7 +82,7 @@ spec:
               value: postgres://postgres:@localhost:5432/?sslmode=disable
             - name: PG_EXPORTER_EXTEND_QUERY_PATH
               value: /config/code_insights_queries.yaml
-          image: index.docker.io/sourcegraph/postgres_exporter:4.5.1@sha256:5e46d12ef16324c00824d7e985665b8a47b561cf0ad7ef0b0ba07c708cd2def6
+          image: index.docker.io/sourcegraph/postgres_exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:0d88b491e837616f563fd3097cd4113338728e857ffee6d57b4c48ba1350af9f
           terminationMessagePolicy: FallbackToLogsOnError
           name: pgsql-exporter
           ports:

--- a/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
         - name: correct-data-dir-permissions
-          image: index.docker.io/sourcegraph/alpine-3.14:4.5.1@sha256:03d0a2ae53bc45b288bc36c820b39596f858296875f93d971a45efbfe86fe014
+          image: index.docker.io/sourcegraph/alpine-3.14:216430_2023-05-02_5.0-3cc9006de32c@sha256:923c803fb975e905424b347e19839ae0077c0dec6eea0cb71c62acd910e8e9c8
           command: ["sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"]
           volumeMounts:
             - mountPath: /data
@@ -45,7 +45,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: index.docker.io/sourcegraph/codeintel-db:4.5.1@sha256:6e20ddd842bebab3c970e6dd13f9a693342ece9a10624710718057dfcb4c986e
+          image: index.docker.io/sourcegraph/codeintel-db:216430_2023-05-02_5.0-3cc9006de32c@sha256:931a3b043d79f4cc7692a96810e18f0db231f36534a6748ea862903768ceeef0
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:
@@ -87,7 +87,7 @@ spec:
               value: postgres://sg:@localhost:5432/?sslmode=disable
             - name: PG_EXPORTER_EXTEND_QUERY_PATH
               value: /config/code_intel_queries.yaml
-          image: index.docker.io/sourcegraph/postgres_exporter:4.5.1@sha256:5e46d12ef16324c00824d7e985665b8a47b561cf0ad7ef0b0ba07c708cd2def6
+          image: index.docker.io/sourcegraph/postgres_exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:0d88b491e837616f563fd3097cd4113338728e857ffee6d57b4c48ba1350af9f
           terminationMessagePolicy: FallbackToLogsOnError
           name: pgsql-exporter
           ports:

--- a/base/sourcegraph/embeddings/embeddings.ConfigMap.yaml
+++ b/base/sourcegraph/embeddings/embeddings.ConfigMap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: embeddings
+    app.kubernetes.io/component: embeddings
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+  name: embeddings-backend
+data:
+  EMBEDDINGS_UPLOAD_BACKEND: blobstore
+  EMBEDDINGS_UPLOAD_AWS_ENDPOINT: http://blobstore:9000

--- a/base/sourcegraph/embeddings/embeddings.Deployment.yaml
+++ b/base/sourcegraph/embeddings/embeddings.Deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    description: Handles embeddings search and indexing
+    description: Handles embeddings searches
   name: embeddings
   labels:
     deploy: sourcegraph

--- a/base/sourcegraph/embeddings/embeddings.Deployment.yaml
+++ b/base/sourcegraph/embeddings/embeddings.Deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: Handles embeddings search and indexing
+  name: embeddings
+  labels:
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: embeddings
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: embeddings
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        deploy: sourcegraph
+        app: embeddings
+    spec:
+      containers:
+        - name: embeddings
+          image: index.docker.io/sourcegraph/embeddings:216430_2023-05-02_5.0-3cc9006de32c@sha256:c8cd7c5abca562d6a79bb524c49b9d0e76a3cb119226baa29ca0508faf652f03
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OTEL_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_AGENT_HOST):4317
+          envFrom:
+            - configMapRef:
+                name: embeddings-backend
+          ports:
+            - containerPort: 9991
+              name: http
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "8"
+              memory: 64G
+            requests:
+              cpu: "4"
+              memory: 32G

--- a/base/sourcegraph/embeddings/embeddings.Deployment.yaml
+++ b/base/sourcegraph/embeddings/embeddings.Deployment.yaml
@@ -54,3 +54,11 @@ spec:
             requests:
               cpu: "4"
               memory: 32G
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsGroup: 101
+            runAsUser: 100
+      securityContext:
+        runAsUser: 100
+        fsGroup: 101
+        fsGroupChangePolicy: "OnRootMismatch"

--- a/base/sourcegraph/embeddings/embeddings.Service.yaml
+++ b/base/sourcegraph/embeddings/embeddings.Service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "6060"
+    sourcegraph.prometheus/scrape: "true"
+  labels:
+    app: embeddings
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: embeddings
+  name: embeddings
+spec:
+  ports:
+    - name: http
+      port: 9991
+      targetPort: http
+  selector:
+    app: embeddings
+  type: ClusterIP

--- a/base/sourcegraph/embeddings/kustomization.yaml
+++ b/base/sourcegraph/embeddings/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - embeddings.ConfigMap.yaml
+  - embeddings.Service.yaml
+  - embeddings.Deployment.yaml

--- a/base/sourcegraph/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/sourcegraph/frontend/sourcegraph-frontend.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       initContainers:
         - name: migrator
-          image: index.docker.io/sourcegraph/migrator:4.5.1@sha256:76211ebd56474a0b6c45050c1e54f3338e2fd9e978a9ff65f246f2c554104d3b
+          image: index.docker.io/sourcegraph/migrator:216430_2023-05-02_5.0-3cc9006de32c@sha256:b8e48a03a546e955eec228843b76f44ca86211c914fc0685f81985a2c20e269b
           args: ["up"]
           resources:
             limits:
@@ -48,7 +48,7 @@ spec:
                 name: sourcegraph-frontend-env
       containers:
         - name: frontend
-          image: index.docker.io/sourcegraph/frontend:4.5.1@sha256:22bb1203a6d8ac9bab442dcfef867efc216181026c3d6fc62415ef1a3f063139
+          image: index.docker.io/sourcegraph/frontend:216430_2023-05-02_5.0-3cc9006de32c@sha256:871772686b707f1e2d18524dc5d23837922eee244c91190ad8a636d88d3563df
           args:
             - serve
           envFrom:

--- a/base/sourcegraph/github-proxy/github-proxy.Deployment.yaml
+++ b/base/sourcegraph/github-proxy/github-proxy.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: github-proxy
-          image: index.docker.io/sourcegraph/github-proxy:4.5.1@sha256:f9260d625d4e469a69cde168acaecb181606053b6b63cdb1b52ecdf65555fb93
+          image: index.docker.io/sourcegraph/github-proxy:216430_2023-05-02_5.0-3cc9006de32c@sha256:30d4550f51febc1e32ec8af175ef8cce4d1706fd75468572da86f6da451f546f
           env:
             # OTEL_AGENT_HOST must be defined before OTEL_EXPORTER_OTLP_ENDPOINT to substitute the node IP on which the DaemonSet pod instance runs in the latter variable
             - name: OTEL_AGENT_HOST

--- a/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
+++ b/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
@@ -35,7 +35,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: index.docker.io/sourcegraph/gitserver:4.5.1@sha256:680226ae13a1f1786dcce9d81fd2517a338b6a18589cc7e3747423d6c049a9e7
+          image: index.docker.io/sourcegraph/gitserver:216430_2023-05-02_5.0-3cc9006de32c@sha256:c8f62c859b789be15ecc78c16e9fbf21cb818262b3880d87e48b05ff8bf2c684
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             initialDelaySeconds: 5

--- a/base/sourcegraph/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/sourcegraph/indexed-search/indexed-search.StatefulSet.yaml
@@ -33,7 +33,7 @@ spec:
               value: http://$(OTEL_AGENT_HOST):4317
             - name: OPENTELEMETRY_DISABLED
               value: "false"
-          image: index.docker.io/sourcegraph/indexed-searcher:4.5.1@sha256:e58d02918558b617fa7533526d51ec176c0277d0051b0cb5aa3d03c84f3963fe
+          image: index.docker.io/sourcegraph/indexed-searcher:216430_2023-05-02_5.0-3cc9006de32c@sha256:818a6d607f8ff35631a98d56ef8feb2a4257b6398473128132d85901c60b8b9d
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 6070
@@ -72,7 +72,7 @@ spec:
               value: http://$(OTEL_AGENT_HOST):4317
             - name: OPENTELEMETRY_DISABLED
               value: "false"
-          image: index.docker.io/sourcegraph/search-indexer:4.5.1@sha256:2cab0ebb22aacec48e65762e819b2bb4a5969ff1feb7a8c7b645e54700fb14ad
+          image: index.docker.io/sourcegraph/search-indexer:216430_2023-05-02_5.0-3cc9006de32c@sha256:42e4dbd82a7038c8cc46f2748e897bdf8d8d0dea9d365151dec7946fabfef687
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 6072

--- a/base/sourcegraph/kustomization.yaml
+++ b/base/sourcegraph/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - blobstore
   - codeinsights-db
   - codeintel-db
+  - embeddings
   - frontend
   - github-proxy
   - gitserver

--- a/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
+++ b/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
         - name: correct-data-dir-permissions
-          image: index.docker.io/sourcegraph/alpine-3.14:4.5.1@sha256:03d0a2ae53bc45b288bc36c820b39596f858296875f93d971a45efbfe86fe014
+          image: index.docker.io/sourcegraph/alpine-3.14:216430_2023-05-02_5.0-3cc9006de32c@sha256:923c803fb975e905424b347e19839ae0077c0dec6eea0cb71c62acd910e8e9c8
           command: ["sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"]
           volumeMounts:
             - mountPath: /data
@@ -46,7 +46,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: index.docker.io/sourcegraph/postgres-12-alpine:4.5.1@sha256:0b1ee2a5b183d14cb3151d74087fa12fbe53f54249f7ed0dee15ffe8ad646eb0
+          image: index.docker.io/sourcegraph/postgres-12-alpine:216430_2023-05-02_5.0-3cc9006de32c@sha256:931a3b043d79f4cc7692a96810e18f0db231f36534a6748ea862903768ceeef0
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:
@@ -90,7 +90,7 @@ spec:
               value: postgres://sg:@localhost:5432/?sslmode=disable
             - name: PG_EXPORTER_EXTEND_QUERY_PATH
               value: /config/queries.yaml
-          image: index.docker.io/sourcegraph/postgres_exporter:4.5.1@sha256:5e46d12ef16324c00824d7e985665b8a47b561cf0ad7ef0b0ba07c708cd2def6
+          image: index.docker.io/sourcegraph/postgres_exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:0d88b491e837616f563fd3097cd4113338728e857ffee6d57b4c48ba1350af9f
           terminationMessagePolicy: FallbackToLogsOnError
           name: pgsql-exporter
           ports:

--- a/base/sourcegraph/precise-code-intel/worker.Deployment.yaml
+++ b/base/sourcegraph/precise-code-intel/worker.Deployment.yaml
@@ -46,7 +46,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: index.docker.io/sourcegraph/precise-code-intel-worker:4.5.1@sha256:39a96a00c2bb7e28dc97a90cfffa9e5993c085bfa93771279174e364056bd9b9
+          image: index.docker.io/sourcegraph/precise-code-intel-worker:216430_2023-05-02_5.0-3cc9006de32c@sha256:6194050008a585b34e841f51529475312c24b17cbe36851d2a4988a5d1defb69
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:

--- a/base/sourcegraph/redis/redis-cache.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-cache.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: redis-cache
-          image: index.docker.io/sourcegraph/redis-cache:4.5.1@sha256:c79f9995992ee01bb7636bf21cce043e5ea03a6edc70673ad18c99cc9850384b
+          image: index.docker.io/sourcegraph/redis-cache:216430_2023-05-02_5.0-3cc9006de32c@sha256:60d9265507efe5b9ae51087bc7433932dfcd84d7e75c2513800baeb93fa9ea0f
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             initialDelaySeconds: 30
@@ -54,7 +54,7 @@ spec:
             - mountPath: /redis-data
               name: redis-data
         - name: redis-exporter
-          image: index.docker.io/sourcegraph/redis_exporter:4.5.1@sha256:edb0c9b19cacd90acc78f13f0908a7e6efd1df704e401805c24bffd241285f70
+          image: index.docker.io/sourcegraph/redis_exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:edb0c9b19cacd90acc78f13f0908a7e6efd1df704e401805c24bffd241285f70
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 9121

--- a/base/sourcegraph/redis/redis-store.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: redis-store
-          image: index.docker.io/sourcegraph/redis-store:4.5.1@sha256:3a3eb92d6f6579dd8c249800d54c906851cfc8821649efe634af344df927d25c
+          image: index.docker.io/sourcegraph/redis-store:216430_2023-05-02_5.0-3cc9006de32c@sha256:fd1640997cad4ce114b98a7885636e6f48483712cea754411cf4d47e770d9219
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             initialDelaySeconds: 30
@@ -53,7 +53,7 @@ spec:
             - mountPath: /redis-data
               name: redis-data
         - name: redis-exporter
-          image: index.docker.io/sourcegraph/redis_exporter:4.5.1@sha256:edb0c9b19cacd90acc78f13f0908a7e6efd1df704e401805c24bffd241285f70
+          image: index.docker.io/sourcegraph/redis_exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:edb0c9b19cacd90acc78f13f0908a7e6efd1df704e401805c24bffd241285f70
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 9121

--- a/base/sourcegraph/repo-updater/repo-updater.Deployment.yaml
+++ b/base/sourcegraph/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: repo-updater
-          image: index.docker.io/sourcegraph/repo-updater:4.5.1@sha256:b2973914ff0d8383909e1c7b4e2e0ab8e68f7eefb82fab994481c18788c9bbae
+          image: index.docker.io/sourcegraph/repo-updater:216430_2023-05-02_5.0-3cc9006de32c@sha256:c91ae5f636b8a7a1b06d6c899da6a2b40f0be91aaf704116dac1c3a491db6517
           env:
             # Required when service discovery is disabled
             - name: GITHUB_BASE_URL

--- a/base/sourcegraph/searcher/searcher.StatefulSet.yaml
+++ b/base/sourcegraph/searcher/searcher.StatefulSet.yaml
@@ -46,7 +46,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: index.docker.io/sourcegraph/searcher:4.5.1@sha256:f684b30f79c81a7c859996287c8c4d4fed32bc0df9bae7817b5821e052566eb5
+          image: index.docker.io/sourcegraph/searcher:216430_2023-05-02_5.0-3cc9006de32c@sha256:4a40c10251454e5fda00f4b367f4f378e19b532bc93ba8a7dbfdefed27e10f05
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 3181

--- a/base/sourcegraph/symbols/symbols.StatefulSet.yaml
+++ b/base/sourcegraph/symbols/symbols.StatefulSet.yaml
@@ -43,7 +43,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: index.docker.io/sourcegraph/symbols:4.5.1@sha256:69e29d5ed4cbe25d87034f53452c2fece7e2b3b208da67b1292d84a2d04761a6
+          image: index.docker.io/sourcegraph/symbols:216430_2023-05-02_5.0-3cc9006de32c@sha256:bcf074d381291574d9e34df9c31665981bd4dc3ca737412bbeedf8fedcc6372b
           livenessProbe:
             httpGet:
               path: /healthz

--- a/base/sourcegraph/syntect-server/syntect-server.Deployment.yaml
+++ b/base/sourcegraph/syntect-server/syntect-server.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsGroup: 101
             runAsUser: 100
-          image: index.docker.io/sourcegraph/syntax-highlighter:4.5.1@sha256:19f3cacf354c23f5a7f9c989958adb0683c5993a914870596bd4c30023a5ae7e
+          image: index.docker.io/sourcegraph/syntax-highlighter:216430_2023-05-02_5.0-3cc9006de32c@sha256:d39a9234cf5f9128d5bf7430448efd4284c505fab6a310c1ec08a62a9d396fea
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:

--- a/base/sourcegraph/worker/worker.Deployment.yaml
+++ b/base/sourcegraph/worker/worker.Deployment.yaml
@@ -51,6 +51,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: embeddings-backend
+                optional: true
           image: index.docker.io/sourcegraph/worker:216430_2023-05-02_5.0-3cc9006de32c@sha256:d3d9e1d684a1a4a337810dc0a9caa95bd9caa17120527be227ca3b5cae622b59
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:

--- a/base/sourcegraph/worker/worker.Deployment.yaml
+++ b/base/sourcegraph/worker/worker.Deployment.yaml
@@ -48,6 +48,9 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
+          envFrom:
+            - configMapRef:
+                name: embeddings-backend
           image: index.docker.io/sourcegraph/worker:216430_2023-05-02_5.0-3cc9006de32c@sha256:d3d9e1d684a1a4a337810dc0a9caa95bd9caa17120527be227ca3b5cae622b59
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:

--- a/base/sourcegraph/worker/worker.Deployment.yaml
+++ b/base/sourcegraph/worker/worker.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: index.docker.io/sourcegraph/worker:4.5.1@sha256:587813191a1eeb3ed67b2bf3ee5e7cf863dd151812737cfea4723698225abe05
+          image: index.docker.io/sourcegraph/worker:216430_2023-05-02_5.0-3cc9006de32c@sha256:d3d9e1d684a1a4a337810dc0a9caa95bd9caa17120527be227ca3b5cae622b59
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:

--- a/components/README.md
+++ b/components/README.md
@@ -6,4 +6,4 @@ These components can include files and other resources that are used to enhance 
 
 ## How to use
 
-See our [Configure Sourcegraph with Kustomize docs](https://docs.sourcegraph.com/admin/deploy/kubernetes/kustomize/configure) for the latested instructions.
+See our [Configure Sourcegraph with Kustomize docs](https://docs.sourcegraph.com/admin/deploy/kubernetes/kustomize/configure) for the latest instructions.

--- a/components/custom/resources/kustomization.yaml
+++ b/components/custom/resources/kustomization.yaml
@@ -496,6 +496,23 @@ patches:
 #                   cpu: "0.5"
 #                   memory: 512Mi
 # - patch: |-
+#     apiVersion: apps/v1
+#     kind: Deployment
+#     metadata:
+#       name: embeddings
+#     spec:
+#       template:
+#         spec:
+#           containers:
+#             - name: embeddings
+#               resources:
+#                 limits:
+#                   cpu: "8"
+#                   memory: "64Gi"
+#                 requests:
+#                   cpu: "4"
+#                   memory: "32Gi"
+# - patch: |-
 #     apiVersion: v1
 #     kind: PersistentVolumeClaim
 #     metadata:

--- a/components/patches/embeddings-backend.yaml
+++ b/components/patches/embeddings-backend.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: embeddings-backend
+data:
+  # Add env vars for `embeddings`, `worker` services below
+  # See [storing-embeddings-indexes](https://docs.sourcegraph.com/cody/explanations/code_graph_context#storing-embedding-indexes) for more details
+  # EMBEDDINGS_UPLOAD_MANAGE_BUCKET: "true"
+  # EMBEDDINGS_REPO_INDEX_CACHE_SIZE: "5"
+
+  ############
+  ##   S3   ##
+  ############
+  # EMBEDDINGS_UPLOAD_BACKEND: S3
+  # EMBEDDINGS_UPLOAD_BUCKET: <my bucket name>
+  # EMBEDDINGS_UPLOAD_AWS_ENDPOINT: https://s3.us-east-1.amazonaws.com
+  # EMBEDDINGS_UPLOAD_AWS_ACCESS_KEY_ID: <your access key>
+  # EMBEDDINGS_UPLOAD_AWS_SECRET_ACCESS_KEY: <your secret key>
+  # EMBEDDINGS_UPLOAD_AWS_SESSION_TOKEN: <your session token> # (optional)
+  # EMBEDDINGS_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS: "true" # (optional; set to use EC2 metadata API over static credentials)
+  # EMBEDDINGS_UPLOAD_AWS_REGION: us-east-1
+
+  #############
+  ##   GCS   ##
+  #############
+  # EMBEDDINGS_UPLOAD_BACKEND: GCS
+  # EMBEDDINGS_UPLOAD_BUCKET: <my bucket name>
+  # EMBEDDINGS_UPLOAD_GCP_PROJECT_ID: <my project id>
+  # EMBEDDINGS_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE: </path/to/file>
+  # EMBEDDINGS_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT: <{"my": "content"}>

--- a/components/remove/embeddings/kustomization.yaml
+++ b/components/remove/embeddings/kustomization.yaml
@@ -3,6 +3,12 @@ kind: Component
 patches:
   - patch: |-
       $patch: delete
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: embeddings-backend
+  - patch: |-
+      $patch: delete
       apiVersion: apps/v1
       kind: Deployment
       metadata:

--- a/components/remove/embeddings/kustomization.yaml
+++ b/components/remove/embeddings/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - patch: |-
+      $patch: delete
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: embeddings
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: embeddings

--- a/instances/README.md
+++ b/instances/README.md
@@ -4,7 +4,7 @@ See the [Sourcegraph Kustomize docs](https://docs.sourcegraph.com/admin/deploy/k
 
 ## Create an overlay for your instances
 
-The [instances/template](template) folder contains a file named [kustomization.template.yaml](template/kustomization.template.yaml)) that is preconfigured to construct a Kustomize overlay for deploying Sourcegraph.
+The [instances/template](template) folder contains a file named [kustomization.template.yaml](template/kustomization.template.yaml) that is preconfigured to construct a Kustomize overlay for deploying Sourcegraph.
 
 **Step 1**: Create a new directory named `$INSTANCE_NAME` within the `instances` subdirectory
 
@@ -29,4 +29,4 @@ cp instances/template/kustomization.template.yaml instances/$INSTANCE_NAME/kusto
 cp instances/template/buildConfig.template.yaml instances/$INSTANCE_NAME/buildConfig.yaml
 ```
 
-**Step 3**: You can begin customizing your Sourcegraph deployment by updating the [kustomization.yaml file](https://docs.sourcegraph.com/admin/deploy/kubernetes/kustomize/intro#kustomization-yaml) inside $INSTANCE_NAME (the directory for your instance). Please follow our [configuration guides](https://docs.sourcegraph.com/admin/deploy/kubernetes/kustomize/configure.md) for guidance.
+**Step 3**: You can begin customizing your Sourcegraph deployment by updating the [kustomization.yaml file](https://docs.sourcegraph.com/admin/deploy/kubernetes/kustomize#kustomization-yaml) inside $INSTANCE_NAME (the directory for your instance). Please follow our [configuration guides](https://docs.sourcegraph.com/admin/deploy/kubernetes/configure) for guidance.

--- a/instances/template/kustomization.template.yaml
+++ b/instances/template/kustomization.template.yaml
@@ -146,6 +146,7 @@ components:
   # - ../../components/utils/uid # -- Run all Postgres database with valid users on host
   # - ../../components/utils/multi-version-upgrade # -- Scale down non-database pods to 0 for multi-version upgrade
   # - ../../components/utils/migrate-to-nonprivileged # -- Component for migrating from privileged to non-privileged
+  - ../../components/remove/embeddings # -- Disable Embeddings service by default
   #
   #---------------------------------------------------------------------------------------
   # Resource migration from deploy-sourcegraph
@@ -216,12 +217,13 @@ components:
 #   #---------------------------------------------------------------------------------------
 #   # custom patches
 #   #---------------------------------------------------------------------------------------
-#   - patch: patches/frontend-ingress.annotations.yaml
-#   - patch: patches/prometheus.ConfigMap.yaml
-#   - patch: patches/pgsql.ConfigMap.yaml
-#   - patch: patches/otel-collector.ConfigMap.yaml
-#   - patch: patches/custom.NodePort.yaml
-#   - patch: patches/resources.yaml
+#   - path: patches/frontend-ingress.annotations.yaml
+#   - path: patches/prometheus.ConfigMap.yaml
+#   - path: patches/pgsql.ConfigMap.yaml
+#   - path: patches/otel-collector.ConfigMap.yaml
+#   - path: patches/custom.NodePort.yaml
+#   - path: patches/resources.yaml
+#   - path: patches/embeddings-backend.yaml
 #
 #   #---------------------------------------------------------------------------------------
 #   # Update env vars for non-frontend services


### PR DESCRIPTION
## Description
Adds Embeddings service for Cody embeddings (disabled by default)
- Can be enabled by commenting out the `../../components/remove/embeddings` component
- Storage backend can be configured using a patch `embeddings-backend.yaml`
  - Patches a configmap which `embeddings` and `worker` pull env from (optional on worker)

<!-- description here -->

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [x] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [x] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [x] Verify all images have a valid tag and SHA256 sum

## Test plan
Tested locally using SG blobstore and GCS
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
