### PR TITLE
Executors: migrate existing executors functionality from `sourcegraph/deploy-sourcegraph` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ known_hosts
 dev-clusters
 test.yaml
 ci-generated-cluster
+.idea

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 golang 1.19.7
 yarn 1.22.4
-kubectl 1.21.7
+kubectl 1.25.9
 fd 7.4.0
 kustomize 4.5.7
 shfmt 3.1.0

--- a/base/monitoring/prometheus/prometheus.yml
+++ b/base/monitoring/prometheus/prometheus.yml
@@ -163,3 +163,4 @@ scrape_configs: # Configure targets to scrape
           - node-exporter:9100
           - otel-collector:8888
           - cadvisor:48080
+          - executor:6060

--- a/components/executors/k8s/README.md
+++ b/components/executors/k8s/README.md
@@ -1,0 +1,19 @@
+# Executors
+
+Executors are Sourcegraph’s solution for running untrusted code in a secure and controllable way. For more information on executors and how they are used see the Executors [documentation](https://docs.sourcegraph.com/admin/executors)
+
+## Deploying
+
+This directory contains components for the optional deployment of Sourcegraph Executors on Kubernetes.
+
+It is expected that all components contained in this directory and any subdirectories are deployed to ensure full functionality and best performance.
+
+The following components will deployed:
+
+- [Executor Deployment](./executor.Deployment.yaml) An Executor replica with a Docker sidecar to run isolated batch changes and auto-indexing jobs. This deployment requires a [privileged security context](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+- [Executor Service](./executor.Service.yaml) A headless service for executor metrics access. Executors are not externally accessible.
+- [Docker ConfigMap](./docker-daemon.ConfigMap.yaml) configuration for the docker sidecar to use the pull-through cache.
+- [Private docker registory]
+    - [Registry Deployment](./private-docker-registry/private-docker-registry.Deployment.yaml) A private docker registry configured as a pull-through cache to avoid docker hub rate limiting.
+    - [Registry Service](./private-docker-registry/private-docker-registry.Service.yaml) A service to access the private-docker-registry.
+    - [Registry Persistent Volume](./private-docker-registry/private-docker-registry.PersistentVolumeClaim.yaml) A volume to store images in the private-docker-registry.

--- a/components/executors/k8s/docker-daemon.ConfigMap.yaml
+++ b/components/executors/k8s/docker-daemon.ConfigMap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  daemon.json: |
+    { "insecure-registries":["private-docker-registry:5000"] }
+
+kind: ConfigMap
+metadata:
+  labels:
+    app: executor
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: executor
+  name: docker-config

--- a/components/executors/k8s/executor.ConfigMap.yaml
+++ b/components/executors/k8s/executor.ConfigMap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: executor-config
+  labels:
+    app: executor
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: executor
+# Refer to https://docs.sourcegraph.com/admin/executors/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
+data:
+  EXECUTOR_FRONTEND_URL: "http://sourcegraph.example.com"
+  EXECUTOR_FRONTEND_PASSWORD: "our-shared-secret"
+  EXECUTOR_USE_FIRECRACKER: "false"
+  EXECUTOR_QUEUE_NAME: "batches"
+  EXECUTOR_JOB_NUM_CPUS: "0"
+  EXECUTOR_JOB_MEMORY: "0"
+  DOCKER_HOST: "tcp://localhost:2375"
+  # Note: Must match the mount point shared with the docker-in-docker (dind) sidecar
+  TMPDIR: "/scratch"

--- a/components/executors/k8s/executor.Deployment.yaml
+++ b/components/executors/k8s/executor.Deployment.yaml
@@ -45,24 +45,9 @@ spec:
             periodSeconds: 5
           terminationMessagePolicy: FallbackToLogsOnError
           # Refer to https://docs.sourcegraph.com/admin/executors/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
-          env:
-            - name: EXECUTOR_FRONTEND_URL
-              value:
-            - name: EXECUTOR_FRONTEND_PASSWORD
-              value:
-            - name: EXECUTOR_USE_FIRECRACKER
-              value: "false"
-            - name: EXECUTOR_QUEUE_NAME
-              value:
-            - name: EXECUTOR_JOB_NUM_CPUS
-              value: "0"
-            - name: EXECUTOR_JOB_MEMORY
-              value: "0"
-            - name: DOCKER_HOST
-              value: tcp://localhost:2375
-            # Note: Must match the mount point shared with the docker-in-docker (dind) sidecar
-            - name: TMPDIR
-              value: /scratch
+          envFrom:
+            - configMapRef:
+                name: executor-config
           volumeMounts:
             - mountPath: /scratch
               name: executor-scratch

--- a/components/executors/k8s/executor.Deployment.yaml
+++ b/components/executors/k8s/executor.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
                 - /usr/local/bin/executor
             periodSeconds: 5
           terminationMessagePolicy: FallbackToLogsOnError
-          # Refer to https://docs.sourcegraph.com/admin/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
+          # Refer to https://docs.sourcegraph.com/admin/executors/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
           env:
             - name: EXECUTOR_FRONTEND_URL
               value:

--- a/components/executors/k8s/executor.Deployment.yaml
+++ b/components/executors/k8s/executor.Deployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: executor
+  annotations:
+    description: Runs sourcegraph executor replicas for batch changes and codeintel auto indexing.
+    kubectl.kubernetes.io/default-container: executor
+  labels:
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: executor
+spec:
+  selector:
+    matchLabels:
+      app: executor
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: executor
+    spec:
+      containers:
+        - name: executor
+          image: index.docker.io/sourcegraph/executor:insiders@sha256:deda81624796df31b56bdaa6820b3332eaa2cbe5e1729886d15ce3c6f57b69b5
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/pgrep
+                - /usr/local/bin/executor
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/pgrep
+                - /usr/local/bin/executor
+            periodSeconds: 5
+          terminationMessagePolicy: FallbackToLogsOnError
+          # Refer to https://docs.sourcegraph.com/admin/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
+          env:
+            - name: EXECUTOR_FRONTEND_URL
+              value:
+            - name: EXECUTOR_FRONTEND_PASSWORD
+              value:
+            - name: EXECUTOR_USE_FIRECRACKER
+              value: "false"
+            - name: EXECUTOR_QUEUE_NAME
+              value:
+            - name: EXECUTOR_JOB_NUM_CPUS
+              value: "0"
+            - name: EXECUTOR_JOB_MEMORY
+              value: "0"
+            - name: DOCKER_HOST
+              value: tcp://localhost:2375
+            # Note: Must match the mount point shared with the docker-in-docker (dind) sidecar
+            - name: TMPDIR
+              value: /scratch
+          volumeMounts:
+            - mountPath: /scratch
+              name: executor-scratch
+        - name: dind
+          image: index.docker.io/sourcegraph/dind:insiders@sha256:06a4a6ac7c200cdd14ebb1cde5be3f02e5df525e1a3e4c1bc258b08e514e550c
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          command:
+            - 'dockerd'
+            - '--tls=false'
+            - '--mtu=1200'
+            - '--registry-mirror=http://private-docker-registry:5000'
+            - '--host=tcp://0.0.0.0:2375'
+          livenessProbe:
+            tcpSocket:
+              port: 2375
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            tcpSocket:
+              port: 2375
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 5
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          ports:
+            - containerPort: 2375
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /scratch
+              name: executor-scratch
+            - mountPath: /etc/docker/daemon.json
+              subPath: daemon.json
+              name: docker-config
+      volumes:
+        - name: executor-scratch
+          emptyDir:
+            # Ensure we don't cause disk pressure on nodes. This value can be adjusted based on the size of the batch change or code intel requirements.
+            # Refer to https://docs.sourcegraph.com/admin/executors/deploy_executors#resource-recommendations for more information
+            sizeLimit: 20Gi
+        - name: docker-config
+          configMap:
+            defaultMode: 420
+            name: docker-config

--- a/components/executors/k8s/executor.Service.yaml
+++ b/components/executors/k8s/executor.Service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "6060"
+    sourcegraph.prometheus/scrape: "true"
+  labels:
+    app: executor
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: executor
+  name: executor
+spec:
+  ports:
+    - name: debug
+      port: 6060
+      targetPort: debug
+  selector:
+    app: executor
+  type: ClusterIP

--- a/components/executors/k8s/kustomization.yaml
+++ b/components/executors/k8s/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Component
 resources:
   - docker-daemon.ConfigMap.yaml
   - executor.Deployment.yaml
+  - executor.ConfigMap.yaml
   - executor.Service.yaml

--- a/components/executors/k8s/kustomization.yaml
+++ b/components/executors/k8s/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - docker-daemon.ConfigMap.yaml
+  - executor.Deployment.yaml
+  - executor.Service.yaml

--- a/components/executors/k8s/private-docker-registry/kustomization.yaml
+++ b/components/executors/k8s/private-docker-registry/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - private-docker-registry.PersistentVolumeClaim.yaml
+  - private-docker-registry.Deployment.yaml
+  - private-docker-registry.Service.yaml

--- a/components/executors/k8s/private-docker-registry/private-docker-registry.Deployment.yaml
+++ b/components/executors/k8s/private-docker-registry/private-docker-registry.Deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: private-docker-registry
+  labels:
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: private-docker-registry
+spec:
+  selector:
+    matchLabels:
+      app: private-docker-registry
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: private-docker-registry
+    spec:
+      containers:
+        - image: index.docker.io/registry:2
+          name: private-docker-registry
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: REGISTRY_PROXY_REMOTEURL
+              value: http://registry-1.docker.io
+          ports:
+            - containerPort: 5000
+              name: registry
+          livenessProbe:
+            httpGet:
+              path: /
+              port: registry
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: registry
+              scheme: HTTP
+            periodSeconds: 5
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /var/lib/registry
+              name: cache
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: private-docker-registry

--- a/components/executors/k8s/private-docker-registry/private-docker-registry.PersistentVolumeClaim.yaml
+++ b/components/executors/k8s/private-docker-registry/private-docker-registry.PersistentVolumeClaim.yaml
@@ -13,4 +13,3 @@ spec:
     requests:
       # To be adjusted based on the number and size of images used in batch changes and auto-indexing
       storage: 100Gi
-  storageClassName: sourcegraph

--- a/components/executors/k8s/private-docker-registry/private-docker-registry.PersistentVolumeClaim.yaml
+++ b/components/executors/k8s/private-docker-registry/private-docker-registry.PersistentVolumeClaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: private-docker-registry
+  labels:
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: private-docker-registry
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # To be adjusted based on the number and size of images used in batch changes and auto-indexing
+      storage: 100Gi
+  storageClassName: sourcegraph

--- a/components/executors/k8s/private-docker-registry/private-docker-registry.Service.yaml
+++ b/components/executors/k8s/private-docker-registry/private-docker-registry.Service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: private-docker-registry
+  name: private-docker-registry
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 5000
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app: private-docker-registry
+  type: ClusterIP

--- a/instances/template/kustomization.template.yaml
+++ b/instances/template/kustomization.template.yaml
@@ -134,8 +134,8 @@ components:
   # Executors
   # See https://docs.sourcegraph.com/admin/executors for information and instructions
   #---------------------------------------------------------------------------------------
-  # ~../../components/executors/k8s # -- Enable executors
-  # ~../../components/executors/k8s/private-docker-registry # -- Enable private docker registry
+  # - ../../components/executors/k8s # -- Enable executors
+  # - ../../components/executors/k8s/private-docker-registry # -- Enable private docker registry
   #
   #---------------------------------------------------------------------------------------
   # Other Configurations

--- a/instances/template/kustomization.template.yaml
+++ b/instances/template/kustomization.template.yaml
@@ -274,7 +274,7 @@ components:
 #         value: 100Gi
 #     target:
 #       kind: PersistentVolumeClaim
-#       name: blobstore|codeinsights-db|codeintel-db|pgsql|prometheus|redis-store|redis-cache
+#       name: blobstore|codeinsights-db|codeintel-db|pgsql|prometheus|redis-store|redis-cache|private-docker-registry
 #
 #   - patch: |-
 #       - op: replace

--- a/instances/template/kustomization.template.yaml
+++ b/instances/template/kustomization.template.yaml
@@ -106,7 +106,7 @@ components:
   # - ../../components/ingress/hostname # -- Set hostname/domain for your Sourcegraph ingress
   # CONFIG KEYS: HOST_DOMAIN
   #
-  # - ../../components/network/tls # -- Enable TLS with exisiting certificates
+  # - ../../components/network/tls # -- Enable TLS with existing certificates
   # CONFIG KEYS: TLS_HOST
   #              TLS_INGRESS_CLASS_NAME
   #              TLS_CLUSTER_ISSUER
@@ -129,6 +129,13 @@ components:
   # - ../../components/services/redis # -- Use external redis servers
   # CONFIG KEYS: REDIS_CACHE_ENDPOINT
   #              REDIS_STORE_ENDPOINT
+  #
+  #---------------------------------------------------------------------------------------
+  # Executors
+  # See https://docs.sourcegraph.com/admin/executors for information and instructions
+  #---------------------------------------------------------------------------------------
+  # ~../../components/executors/k8s # -- Enable executors
+  # ~../../components/executors/k8s/private-docker-registry # -- Enable private docker registry
   #
   #---------------------------------------------------------------------------------------
   # Other Configurations
@@ -210,7 +217,7 @@ components:
 # Create a directory `patches` and then copy the required files as
 # instructed by the configuration docs to update ConfigMaps and other
 # resources using patch files to customize your deployment
-# Do not use the built-in replcias field to update replica counts
+# Do not use the built-in replicas field to update replica counts
 ##########################################################################################
 #
 # patches:


### PR DESCRIPTION
## Description

Migrate existing executors functionality from `sourcegraph/deploy-sourcegraph` as new Kustomize component.

Closes https://github.com/sourcegraph/sourcegraph/issues/51894
Closes https://github.com/sourcegraph/sourcegraph/issues/50599

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->


- [x] Kustomiz-specific changes
- [x] Verify all images have a valid tag and SHA256 sum

## Test plan
Deployed `codeintel` executor using component and verified on `site-admin/executors` page.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
