### PR TITLE
bump migrator image tag and unquote for `sg ops update-images`

### DIFF
--- a/components/utils/migrator/resources/migrator.Job.yaml
+++ b/components/utils/migrator/resources/migrator.Job.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: migrator
-          image: "index.docker.io/sourcegraph/migrator:4.2.0@sha256:d816e125395e99d8a25564f5a799f0e9bedf7c6230065619849e169d0865a35e"
+          image: index.docker.io/sourcegraph/migrator:5.1.6@sha256:76facd38029ee611e5bee723736e42eedb633b2c31d4494711c55f59906a5f93
           args: ["up"]
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## Description
Bumps the migrator to the latest version and unquotes it, otherwise `sg ops update-images` doesn't work (and is part of the release tool).


---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan
None necessary
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
