### PR TITLE
private registry patch should specify initContainers

### DIFF
--- a/components/enable/private-registry/kustomization.yaml
+++ b/components/enable/private-registry/kustomization.yaml
@@ -8,7 +8,6 @@ replacements:
     targets:
       - fieldPaths:
           - spec.template.spec.containers.*.image
-          - spec.template.spec.initContainers.*.image
         options:
           delimiter: /sourcegraph
         select:
@@ -16,7 +15,6 @@ replacements:
           kind: Deployment
       - fieldPaths:
           - spec.template.spec.containers.*.image
-          - spec.template.spec.initContainers.*.image
         options:
           delimiter: /sourcegraph
         select:
@@ -24,9 +22,40 @@ replacements:
           kind: StatefulSet
       - fieldPaths:
           - spec.template.spec.containers.*.image
-          - spec.template.spec.initContainers.*.image
         options:
           delimiter: /sourcegraph
         select:
           group: apps
           kind: DaemonSet
+      - fieldPaths:
+          - spec.template.spec.initContainers.*.image
+        options:
+          delimiter: /sourcegraph
+        select:
+          group: apps
+          kind: Deployment
+          name: sourcegraph-frontend
+      - fieldPaths:
+          - spec.template.spec.initContainers.*.image
+        options:
+          delimiter: /sourcegraph
+        select:
+          group: apps
+          kind: StatefulSet
+          name: codeinsights-db
+      - fieldPaths:
+          - spec.template.spec.initContainers.*.image
+        options:
+          delimiter: /sourcegraph
+        select:
+          group: apps
+          kind: StatefulSet
+          name: codeintel-db
+      - fieldPaths:
+          - spec.template.spec.initContainers.*.image
+        options:
+          delimiter: /sourcegraph
+        select:
+          group: apps
+          kind: StatefulSet
+          name: pgsql


### PR DESCRIPTION
## Description

Fixing the following bug:
```bash
$ kustomize build --load-restrictor LoadRestrictionsNone                            
Error: accumulating components: accumulateDirectory: "recursed accumulation of path '/Users/louis.jarvis@sourcegraph.com/git/deploy-sourcegraph-k8s/components/enable/private-registry': unable to find field \"spec.template.spec.initContainers.*.image\" in replacement target"
```
- To my knowledge there is no way to dynamically select `initContainers` among k8s resources or suppress this build error when an `initContainer` is not found
- Therefore, we need to specify which Deployments / StatefulSets contain an `initContainer`

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

tested locally
