### PR TITLE
rfc-795: add release manifest

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -26,9 +26,9 @@ steps:
   - label: "Release: test"
     if: "build.branch =~ /^wip_/"
     command: |
-      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz 
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz
-      chmod +x ./sg-rfc795 
+      chmod +x ./sg-rfc795
 
       ./sg-rfc795 release run test --workdir=. --config-from-commit
 
@@ -37,8 +37,15 @@ steps:
   - label: "Release: finalize"
     if: "build.branch =~ /^wip_/"
     command: |
-      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz 
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz
-      chmod +x ./sg-rfc795 
+      chmod +x ./sg-rfc795
 
       ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
+  - label: "Promote release to public"
+    if: "build.env(RELEASE_PUBLIC) == true"
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      ./sg-rfc795 release promote-to-public --workdir=. --inputs=server=v5.3.666 --version=v5.3.666

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -43,7 +43,8 @@ steps:
 
       ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
   - label: "Promote release to public"
-    if: "build.env(RELEASE_PUBLIC) == true"
+    if: build.env("RELEASE_PUBLIC") == "true"
+    command: |
       wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz
       chmod +x ./sg-rfc795

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -30,7 +30,7 @@ steps:
       tar zxf sg-rfc795.tar.gz
       chmod +x ./sg-rfc795 
 
-      ./sg-rfc795 release test --workdir=. --config-from-commit
+      ./sg-rfc795 release run test --workdir=. --config-from-commit
 
   - wait
 

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -22,3 +22,10 @@ steps:
   - label: ":k8s:"
     command: .buildkite/verify-overlays.sh
     agents: { queue: standard }
+
+  - label: "Release: finalize"
+    if: "build.branch =~ /^wip_v/"
+    command: |
+      git checkout -b release-test-jh
+      git push origin
+      git checkout -

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -43,7 +43,7 @@ steps:
 
       ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
   - label: "Promote to public: finalize"
-    if: "build.message =~ /^PRETEND PROMOTE RELEASE WIP/"
+    if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
     command: |
       wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -23,6 +23,15 @@ steps:
     command: .buildkite/verify-overlays.sh
     agents: { queue: standard }
 
+  - label: "Release: test"
+    if: "build.branch =~ /^wip_/"
+    command: |
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz 
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795 
+
+      ./sg-rfc795 release test --workdir=. --config-from-commit
+
   - wait
 
   - label: "Release: finalize"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -42,11 +42,11 @@ steps:
       chmod +x ./sg-rfc795
 
       ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
-  - label: "Promote release to public"
-    if: build.env("RELEASE_PUBLIC") == "true"
+  - label: "Promote to public: finalize"
+    if: "build.message =~ /^PRETEND PROMOTE RELEASE WIP/"
     command: |
       wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
       tar zxf sg-rfc795.tar.gz
       chmod +x ./sg-rfc795
 
-      ./sg-rfc795 release promote-to-public --workdir=. --inputs=server=v5.3.666 --version=v5.3.666
+      ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -24,8 +24,10 @@ steps:
     agents: { queue: standard }
 
   - label: "Release: finalize"
-    if: "build.branch =~ /^wip_v/"
+    if: "build.branch =~ /^wip_/"
     command: |
-      git checkout -b release-test-jh
-      git push origin
-      git checkout -
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz 
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795 
+
+      ./sg-rfc795 release finalize --workdir=. --config-from-commit

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -23,6 +23,8 @@ steps:
     command: .buildkite/verify-overlays.sh
     agents: { queue: standard }
 
+  - wait
+
   - label: "Release: finalize"
     if: "build.branch =~ /^wip_/"
     command: |

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -41,4 +41,4 @@ steps:
       tar zxf sg-rfc795.tar.gz
       chmod +x ./sg-rfc795 
 
-      ./sg-rfc795 release finalize --workdir=. --config-from-commit
+      ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit

--- a/release.yaml
+++ b/release.yaml
@@ -45,7 +45,7 @@ create:
         cmd: |
           find . -name "*.yaml" | xargs git add 
           find . -name "*.yml" | xargs git add 
-          git commit -m "release_patch: build {{output.version}}"
+          git commit -m "release_patch: {{version}}" -m "{{config}}"
       - name: "git"
         cmd: |
           git push origin wip_{{version}}
@@ -58,5 +58,5 @@ finalize:
     - name: "git"
       cmd: |
         git checkout -b release-{{version}}
-        git push origin
+        git push origin release-{{version}}
         git checkout - 

--- a/release.yaml
+++ b/release.yaml
@@ -38,12 +38,12 @@ internal:
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
               components/executors/
-        - name: "git"
+        - name: "git:branch"
           cmd: |
             echo "Creating branch wip_{{version}}"
             release_branch="wip_{{version}}"
             git checkout -b $release_branch
-        - name: "git"
+        - name: "git:commit"
           cmd: |
             find . -name "*.yaml" | xargs git add
             find . -name "*.yml" | xargs git add
@@ -51,12 +51,88 @@ internal:
             # to the shell dropping out all quotes from the json, leading to failed
             # parsing.
             git commit -m "release_patch: {{version}}" -m '{{config}}'
-        - name: "git"
+        - name: "git:push"
           cmd: |
             git push origin wip_{{version}}
         - name: "gh cli"
           cmd: |
             gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"  # -l "wip_release"
+      minor:
+        - name: "sg ops (base)"
+          cmd: |
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              base/
+        - name: "sg ops (executors)"
+          cmd: |
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              components/executors/
+        - name: "git:branch"
+          cmd: |
+            echo "Creating branch wip_{{version}}"
+            release_branch="wip_{{version}}"
+            git checkout -b $release_branch
+        - name: "git:commit"
+          cmd: |
+            find . -name "*.yaml" | xargs git add
+            find . -name "*.yml" | xargs git add
+            # Careful with the quoting for the config, using double quotes will lead
+            # to the shell dropping out all quotes from the json, leading to failed
+            # parsing.
+            git commit -m "release_minor: {{version}}" -m '{{config}}'
+        - name: "git:push"
+          cmd: |
+            git push origin wip_{{version}}
+        - name: "gh cli"
+          cmd: |
+            gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"  # -l "wip_release"
+      major:
+        - name: "sg ops (base)"
+          cmd: |
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              base/
+        - name: "sg ops (executors)"
+          cmd: |
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              components/executors/
+        - name: "git:branch"
+          cmd: |
+            echo "Creating branch wip_{{version}}"
+            release_branch="wip_{{version}}"
+            git checkout -b $release_branch
+        - name: "git:commit"
+          cmd: |
+            find . -name "*.yaml" | xargs git add
+            find . -name "*.yml" | xargs git add
+            # Careful with the quoting for the config, using double quotes will lead
+            # to the shell dropping out all quotes from the json, leading to failed
+            # parsing.
+            git commit -m "release_patch: {{version}}" -m '{{config}}'
+        - name: "git:push"
+          cmd: |
+            git push origin wip_{{version}}
+        - name: "gh cli"
+          cmd: |
+            gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"  # -l "wip_release"
   finalize:
     steps:
       - name: "git"
@@ -97,12 +173,12 @@ promoteToPublic:
             --docker-password=$DOCKER_PASSWORD \
             --pin-tag {{inputs.server.tag}} \
             components/executors/
-      - name: "git"
+      - name: "git:branch"
         cmd: |
           echo "Creating branch promote-release_{{version}}"
           branch="promote-release_{{version}}"
           git checkout -b $branch
-      - name: "git"
+      - name: "git:commit"
         cmd: |
           find . -name "*.yaml" | xargs git add
           find . -name "*.yml" | xargs git add

--- a/release.yaml
+++ b/release.yaml
@@ -1,7 +1,9 @@
-productName: deploy-sourcegraph-k8s
-repository: "github.com/sourcegraph/deploy-sourcegraph-k8s"
-owners:
-  - "@sourcegraph/release"
+meta:
+  productName: deploy-sourcegraph-k8s
+  repository: "github.com/sourcegraph/deploy-sourcegraph-k8s"
+  owners:
+    - "@sourcegraph/release"
+
 requirements:
   - name: "Github CLI"
     cmd: gh version
@@ -10,37 +12,42 @@ requirements:
     env: DOCKER_USERNAME
   - name: "Docker password"
     env: DOCKER_PASSWORD
-steps:
-  patch:
-    - name: "sg ops (base)"
-      cmd: |
-        sg ops update-images \
-          --kind k8s \
-          --docker-username=$DOCKER_USERNAME \
-          --docker-password=$DOCKER_PASSWORD \
-          --pin-tag {{tag}} \
-          base/ 
-    # - name: "sg ops (executors)"
-    #   cmd: |
-    #     sg ops update-images \
-    #       --kind k8s \
-    #       --docker-username=$DOCKER_USERNAME \
-    #       --docker-password=$DOCKER_PASSWORD \
-    #       --pin-tag {{tag}} \
-    #       components/executors/
-    - name: "git"
-      cmd: |
-        echo "Creating branch wip_{{version}}"
-        release_branch="wip_{{version}}"
-        git checkout -b $release_branch
-    - name: "git"
-      cmd: |
-        find . -name "*.yaml" | xargs git add 
-        find . -name "*.yml" | xargs git add 
-        git commit -m "release_patch: build {{version}}"
-    - name: "git"
-      cmd: |
-        git push origin wip_{{version}}
-    - name: "gh cli"
-      cmd: |
-        gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"
+
+inputs:
+  - releaseId: server
+
+create:
+  steps:
+    patch:
+      - name: "sg ops (base)"
+        cmd: |
+          sg ops update-images \
+            --kind k8s \
+            --docker-username=$DOCKER_USERNAME \
+            --docker-password=$DOCKER_PASSWORD \
+            --pin-tag wip_{{inputs.server.tag}} \
+            base/ 
+      # - name: "sg ops (executors)"
+      #   cmd: |
+      #     sg ops update-images \
+      #       --kind k8s \
+      #       --docker-username=$DOCKER_USERNAME \
+      #       --docker-password=$DOCKER_PASSWORD \
+      #       --pin-tag {{tag}} \
+      #       components/executors/
+      - name: "git"
+        cmd: |
+          echo "Creating branch wip_{{version}}"
+          release_branch="wip_{{version}}"
+          git checkout -b $release_branch
+      - name: "git"
+        cmd: |
+          find . -name "*.yaml" | xargs git add 
+          find . -name "*.yml" | xargs git add 
+          git commit -m "release_patch: build {{output.version}}"
+      - name: "git"
+        cmd: |
+          git push origin wip_{{version}}
+      - name: "gh cli"
+        cmd: |
+          gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"

--- a/release.yaml
+++ b/release.yaml
@@ -80,7 +80,6 @@ promoteToPublic:
           git checkout origin/wip-release-{{version}}
       - name: "sg ops"
         cmd: |
-          # TODO switch to public
           sg-rfc795 ops update-images \
             --kind k8s \
             --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
@@ -105,3 +104,11 @@ promoteToPublic:
         cmd: |
           git push origin promote-release_{{version}}
           gh pr create -f -t "PRETEND PROMOTE RELEASE WIP: promote-release: build {{version}}" --base wip-release-{{version}}
+    finalize:
+      steps:
+        - name: git:tag
+          cmd: |
+            branch="wip-release_{{version}}"
+            git checkout ${branch}
+            git tag {{version}}
+            git push origin ${branch} --tags

--- a/release.yaml
+++ b/release.yaml
@@ -46,12 +46,12 @@ create:
           find . -name "*.yaml" | xargs git add 
           find . -name "*.yml" | xargs git add 
           git commit -m "release_patch: {{version}}" -m "{{config}}"
-      - name: "git"
-        cmd: |
-          git push origin wip_{{version}}
-      - name: "gh cli"
-        cmd: |
-          gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"
+      # - name: "git"
+      #   cmd: |
+      #     git push origin wip_{{version}}
+      # - name: "gh cli"
+      #   cmd: |
+      #     gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"
 
 finalize:
   steps:

--- a/release.yaml
+++ b/release.yaml
@@ -4,6 +4,9 @@ meta:
   owners:
     - "@sourcegraph/release"
 
+inputs:
+  - releaseId: server
+
 requirements:
   - name: "Github CLI"
     cmd: gh version
@@ -12,9 +15,6 @@ requirements:
     env: DOCKER_USERNAME
   - name: "Docker password"
     env: DOCKER_PASSWORD
-
-inputs:
-  - releaseId: server
 
 create:
   steps:
@@ -63,3 +63,9 @@ finalize:
         git checkout -b release-{{version}}
         git push origin release-{{version}}
         git checkout - 
+
+test: 
+  steps: 
+    - name: "placeholder"
+      cmd: |
+        echo "-- pretending to test release ..."

--- a/release.yaml
+++ b/release.yaml
@@ -16,53 +16,53 @@ requirements:
   - name: "Docker password"
     env: DOCKER_PASSWORD
 
-create:
-  steps:
-    patch:
-      - name: "sg ops (base)"
-        cmd: |
-          sg ops update-images \
-            --kind k8s \
-            --registry internal \
-            --docker-username=$DOCKER_USERNAME \
-            --docker-password=$DOCKER_PASSWORD \
-            --pin-tag wip_v{{inputs.server.tag}} \
-            base/ 
-      # - name: "sg ops (executors)"
-      #   cmd: |
-      #     sg ops update-images \
-      #       --kind k8s \
-      #       --docker-username=$DOCKER_USERNAME \
-      #       --docker-password=$DOCKER_PASSWORD \
-      #       --pin-tag {{tag}} \
-      #       components/executors/
+internal:
+  create:
+    steps:
+      patch:
+        - name: "sg ops (base)"
+          cmd: |
+            sg ops update-images \
+              --kind k8s \
+              --registry internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag wip_v{{inputs.server.tag}} \
+              base/ 
+        # - name: "sg ops (executors)"
+        #   cmd: |
+        #     sg ops update-images \
+        #       --kind k8s \
+        #       --docker-username=$DOCKER_USERNAME \
+        #       --docker-password=$DOCKER_PASSWORD \
+        #       --pin-tag {{tag}} \
+        #       components/executors/
+        - name: "git"
+          cmd: |
+            echo "Creating branch wip_{{version}}"
+            release_branch="wip_{{version}}"
+            git checkout -b $release_branch
+        - name: "git"
+          cmd: |
+            find . -name "*.yaml" | xargs git add 
+            find . -name "*.yml" | xargs git add 
+            # Careful with the quoting for the config, using double quotes will lead 
+            # to the shell dropping out all quotes from the json, leading to failed 
+            # parsing.
+            git commit -m "release_patch: {{version}}" -m '{{config}}'
+        - name: "git"
+          cmd: |
+            git push origin wip_{{version}}
+        - name: "gh cli"
+          cmd: |
+            gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"
+  finalize:
+    steps:
       - name: "git"
         cmd: |
-          echo "Creating branch wip_{{version}}"
-          release_branch="wip_{{version}}"
-          git checkout -b $release_branch
-      - name: "git"
-        cmd: |
-          find . -name "*.yaml" | xargs git add 
-          find . -name "*.yml" | xargs git add 
-          # Careful with the quoting for the config, using double quotes will lead 
-          # to the shell dropping out all quotes from the json, leading to failed 
-          # parsing.
-          git commit -m "release_patch: {{version}}" -m '{{config}}'
-      - name: "git"
-        cmd: |
-          git push origin wip_{{version}}
-      - name: "gh cli"
-        cmd: |
-          gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"
-
-finalize:
-  steps:
-    - name: "git"
-      cmd: |
-        git checkout -b release-{{version}}
-        git push origin release-{{version}}
-        git checkout - 
+          git checkout -b release-{{version}}
+          git push origin release-{{version}}
+          git checkout - 
 
 test: 
   steps: 

--- a/release.yaml
+++ b/release.yaml
@@ -45,13 +45,16 @@ create:
         cmd: |
           find . -name "*.yaml" | xargs git add 
           find . -name "*.yml" | xargs git add 
-          git commit -m "release_patch: {{version}}" -m "{{config}}"
-      # - name: "git"
-      #   cmd: |
-      #     git push origin wip_{{version}}
-      # - name: "gh cli"
-      #   cmd: |
-      #     gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"
+          # Careful with the quoting for the config, using double quotes will lead 
+          # to the shell dropping out all quotes from the json, leading to failed 
+          # parsing.
+          git commit -m "release_patch: {{version}}" -m '{{config}}'
+      - name: "git"
+        cmd: |
+          git push origin wip_{{version}}
+      - name: "gh cli"
+        cmd: |
+          gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"
 
 finalize:
   steps:

--- a/release.yaml
+++ b/release.yaml
@@ -26,7 +26,7 @@ create:
             --registry internal \
             --docker-username=$DOCKER_USERNAME \
             --docker-password=$DOCKER_PASSWORD \
-            --pin-tag wip_{{inputs.server.tag}} \
+            --pin-tag wip_v{{inputs.server.tag}} \
             base/ 
       # - name: "sg ops (executors)"
       #   cmd: |

--- a/release.yaml
+++ b/release.yaml
@@ -52,3 +52,11 @@ create:
       - name: "gh cli"
         cmd: |
           gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"
+
+finalize:
+  steps:
+    - name: "git"
+      cmd: |
+        git checkout -b release-{{version}}
+        git push origin
+        git checkout - 

--- a/release.yaml
+++ b/release.yaml
@@ -23,6 +23,7 @@ create:
         cmd: |
           sg ops update-images \
             --kind k8s \
+            --registry internal \
             --docker-username=$DOCKER_USERNAME \
             --docker-password=$DOCKER_PASSWORD \
             --pin-tag wip_{{inputs.server.tag}} \

--- a/release.yaml
+++ b/release.yaml
@@ -27,7 +27,7 @@ internal:
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
-              --pin-tag wip_v{{inputs.server.tag}} \
+              --pin-tag {{inputs.server.tag}} \
               base/
         # - name: "sg ops (executors)"
         #   cmd: |
@@ -104,4 +104,4 @@ promoteToPublic:
       - name: "github"
         cmd: |
           git push origin promote-release_{{version}}
-          gh pr create -f -t "PRETEND PROMOTE RELEASE WIP: promote-release: build {{version}}" --base release-{{version}}
+          gh pr create -f -t "PRETEND PROMOTE RELEASE WIP: promote-release: build {{version}}" --base wip-release-{{version}}

--- a/release.yaml
+++ b/release.yaml
@@ -29,14 +29,15 @@ internal:
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
               base/
-        # - name: "sg ops (executors)"
-        #   cmd: |
-        #     sg ops update-images \
-        #       --kind k8s \
-        #       --docker-username=$DOCKER_USERNAME \
-        #       --docker-password=$DOCKER_PASSWORD \
-        #       --pin-tag {{tag}} \
-        #       components/executors/
+        - name: "sg ops (executors)"
+          cmd: |
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              components/executors/
         - name: "git"
           cmd: |
             echo "Creating branch wip_{{version}}"
@@ -87,6 +88,15 @@ promoteToPublic:
             --docker-password=$DOCKER_PASSWORD \
             --pin-tag {{inputs.server.tag}} \
             base/
+      - name: "sg ops (executors)"
+        cmd: |
+          sg-rfc795 ops update-images \
+            --kind k8s \
+            --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+            --docker-username=$DOCKER_USERNAME \
+            --docker-password=$DOCKER_PASSWORD \
+            --pin-tag {{inputs.server.tag}} \
+            components/executors/
       - name: "git"
         cmd: |
           echo "Creating branch promote-release_{{version}}"

--- a/release.yaml
+++ b/release.yaml
@@ -22,13 +22,13 @@ internal:
       patch:
         - name: "sg ops (base)"
           cmd: |
-            sg ops update-images \
+            sg-rfc795 ops update-images \
               --kind k8s \
-              --registry internal \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag wip_v{{inputs.server.tag}} \
-              base/ 
+              base/
         # - name: "sg ops (executors)"
         #   cmd: |
         #     sg ops update-images \
@@ -44,10 +44,10 @@ internal:
             git checkout -b $release_branch
         - name: "git"
           cmd: |
-            find . -name "*.yaml" | xargs git add 
-            find . -name "*.yml" | xargs git add 
-            # Careful with the quoting for the config, using double quotes will lead 
-            # to the shell dropping out all quotes from the json, leading to failed 
+            find . -name "*.yaml" | xargs git add
+            find . -name "*.yml" | xargs git add
+            # Careful with the quoting for the config, using double quotes will lead
+            # to the shell dropping out all quotes from the json, leading to failed
             # parsing.
             git commit -m "release_patch: {{version}}" -m '{{config}}'
         - name: "git"
@@ -60,12 +60,12 @@ internal:
     steps:
       - name: "git"
         cmd: |
-          git checkout -b release-{{version}}
-          git push origin release-{{version}}
-          git checkout - 
+          git checkout -b wip-release-{{version}}
+          git push origin wip-release-{{version}}
+          git checkout -
 
-test: 
-  steps: 
+test:
+  steps:
     - name: "placeholder"
       cmd: |
         echo "-- pretending to test release ..."
@@ -75,19 +75,19 @@ promoteToPublic:
     steps:
       - name: "git"
         cmd: |
-          echo "Checking out origin/release-{{version}}"
+          echo "Checking out origin/wip-release-{{version}}"
           git fetch origin
-          git checkout origin/release-{{version}}
+          git checkout origin/wip-release-{{version}}
       - name: "sg ops"
         cmd: |
           # TODO switch to public
-          sg ops update-images \
+          sg-rfc795 ops update-images \
             --kind k8s \
-            --registry internal \
+            --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
             --docker-username=$DOCKER_USERNAME \
             --docker-password=$DOCKER_PASSWORD \
             --pin-tag wip_v{{inputs.server.tag}} \
-            base/ 
+            base/
       - name: "git"
         cmd: |
           echo "Creating branch promote-release_{{version}}"
@@ -95,10 +95,10 @@ promoteToPublic:
           git checkout -b $branch
       - name: "git"
         cmd: |
-          find . -name "*.yaml" | xargs git add 
-          find . -name "*.yml" | xargs git add 
-          # Careful with the quoting for the config, using double quotes will lead 
-          # to the shell dropping out all quotes from the json, leading to failed 
+          find . -name "*.yaml" | xargs git add
+          find . -name "*.yml" | xargs git add
+          # Careful with the quoting for the config, using double quotes will lead
+          # to the shell dropping out all quotes from the json, leading to failed
           # parsing.
           git commit -m "promote_release: {{version}}" -m '{{config}}'
       - name: "github"

--- a/release.yaml
+++ b/release.yaml
@@ -1,0 +1,46 @@
+productName: deploy-sourcegraph-k8s
+repository: "github.com/sourcegraph/deploy-sourcegraph-k8s"
+owners:
+  - "@sourcegraph/release"
+requirements:
+  - name: "Github CLI"
+    cmd: gh version
+    fixInstructions: brew install gh
+  - name: "Docker username"
+    env: DOCKER_USERNAME
+  - name: "Docker password"
+    env: DOCKER_PASSWORD
+steps:
+  patch:
+    - name: "sg ops (base)"
+      cmd: |
+        sg ops update-images \
+          --kind k8s \
+          --docker-username=$DOCKER_USERNAME \
+          --docker-password=$DOCKER_PASSWORD \
+          --pin-tag {{tag}} \
+          base/ 
+    # - name: "sg ops (executors)"
+    #   cmd: |
+    #     sg ops update-images \
+    #       --kind k8s \
+    #       --docker-username=$DOCKER_USERNAME \
+    #       --docker-password=$DOCKER_PASSWORD \
+    #       --pin-tag {{tag}} \
+    #       components/executors/
+    - name: "git"
+      cmd: |
+        echo "Creating branch wip_{{version}}"
+        release_branch="wip_{{version}}"
+        git checkout -b $release_branch
+    - name: "git"
+      cmd: |
+        find . -name "*.yaml" | xargs git add 
+        find . -name "*.yml" | xargs git add 
+        git commit -m "release_patch: build {{version}}"
+    - name: "git"
+      cmd: |
+        git push origin wip_{{version}}
+    - name: "gh cli"
+      cmd: |
+        gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"

--- a/release.yaml
+++ b/release.yaml
@@ -104,11 +104,12 @@ promoteToPublic:
         cmd: |
           git push origin promote-release_{{version}}
           gh pr create -f -t "PRETEND PROMOTE RELEASE WIP: promote-release: build {{version}}" --base wip-release-{{version}}
-    finalize:
-      steps:
-        - name: git:tag
-          cmd: |
-            branch="wip-release_{{version}}"
-            git checkout ${branch}
-            git tag {{version}}
-            git push origin ${branch} --tags
+  finalize:
+    # These steps should only really run once the pr created in the create step is merged
+    steps:
+      - name: git:tag
+        cmd: |
+          branch="wip-release-{{version}}"
+          git checkout ${branch}
+          git tag {{version}}
+          git push origin ${branch} --tags

--- a/release.yaml
+++ b/release.yaml
@@ -55,7 +55,7 @@ internal:
             git push origin wip_{{version}}
         - name: "gh cli"
           cmd: |
-            gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" # -l "wip_release"
+            gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"  # -l "wip_release"
   finalize:
     steps:
       - name: "git"
@@ -103,7 +103,7 @@ promoteToPublic:
       - name: "github"
         cmd: |
           git push origin promote-release_{{version}}
-          gh pr create -f -t "PRETEND PROMOTE RELEASE WIP: promote-release: build {{version}}" --base wip-release-{{version}}
+          gh pr create -f -t "PRETEND PROMOTE RELEASE WIP: promote-release: build {{version}}" --base wip-release-{{version}} --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     # These steps should only really run once the pr created in the create step is merged
     steps:

--- a/release.yaml
+++ b/release.yaml
@@ -69,3 +69,39 @@ test:
     - name: "placeholder"
       cmd: |
         echo "-- pretending to test release ..."
+
+promoteToPublic:
+  create:
+    steps:
+      - name: "git"
+        cmd: |
+          echo "Checking out origin/release-{{version}}"
+          git fetch origin
+          git checkout origin/release-{{version}}
+      - name: "sg ops"
+        cmd: |
+          # TODO switch to public
+          sg ops update-images \
+            --kind k8s \
+            --registry internal \
+            --docker-username=$DOCKER_USERNAME \
+            --docker-password=$DOCKER_PASSWORD \
+            --pin-tag wip_v{{inputs.server.tag}} \
+            base/ 
+      - name: "git"
+        cmd: |
+          echo "Creating branch promote-release_{{version}}"
+          branch="promote-release_{{version}}"
+          git checkout -b $branch
+      - name: "git"
+        cmd: |
+          find . -name "*.yaml" | xargs git add 
+          find . -name "*.yml" | xargs git add 
+          # Careful with the quoting for the config, using double quotes will lead 
+          # to the shell dropping out all quotes from the json, leading to failed 
+          # parsing.
+          git commit -m "promote_release: {{version}}" -m '{{config}}'
+      - name: "github"
+        cmd: |
+          git push origin promote-release_{{version}}
+          gh pr create -f -t "PRETEND PROMOTE RELEASE WIP: promote-release: build {{version}}" --base release-{{version}}

--- a/release.yaml
+++ b/release.yaml
@@ -86,7 +86,7 @@ promoteToPublic:
             --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
             --docker-username=$DOCKER_USERNAME \
             --docker-password=$DOCKER_PASSWORD \
-            --pin-tag wip_v{{inputs.server.tag}} \
+            --pin-tag {{inputs.server.tag}} \
             base/
       - name: "git"
         cmd: |


### PR DESCRIPTION
Adds a release manifest for use with rfc-795 release tooling

Closes https://github.com/sourcegraph/sourcegraph/issues/59061

## TODO

- [ ] remove wip prefixes
- [ ] use normal sg instead of custom rfc build

## Test plan
Executed locally