### PR TITLE
chg/rel: use default sg for release operations

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,52 +1,57 @@
 steps:
-  - label: ":k8s:"
-    command: .buildkite/verify-yaml.sh
-    agents: { queue: standard }
+  - label: 'Showing sg help'
+    command: sg --help
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
 
-  - label: ":k8s:"
-    command: .buildkite/verify-label.sh
-    agents: { queue: standard }
-
-  - label: ":k8s:"
-    command: .buildkite/verify-rbac-labels.sh
-    agents: { queue: standard }
-
-  - label: ":git: :sleuth_or_spy:"
-    command: .buildkite/verify-release/verify-release.sh
-    agents: { queue: standard }
-
-  - label: ":k8s: :sleuth_or_spy:"
-    command: .buildkite/check-image-names.sh
-    agents: { queue: standard }
-
-  - label: ":k8s:"
-    command: .buildkite/verify-overlays.sh
-    agents: { queue: standard }
-
-  - label: "Release: test"
-    if: "build.branch =~ /^wip_/"
-    command: |
-      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
-      tar zxf sg-rfc795.tar.gz
-      chmod +x ./sg-rfc795
-
-      ./sg-rfc795 release run test --workdir=. --config-from-commit
-
-  - wait
-
-  - label: "Release: finalize"
-    if: "build.branch =~ /^wip_/"
-    command: |
-      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
-      tar zxf sg-rfc795.tar.gz
-      chmod +x ./sg-rfc795
-
-      ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
-  - label: "Promote to public: finalize"
-    if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
-    command: |
-      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
-      tar zxf sg-rfc795.tar.gz
-      chmod +x ./sg-rfc795
-
-      ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit
+  # - label: ":k8s:"
+  #   command: .buildkite/verify-yaml.sh
+  #   agents: { queue: standard }
+  #
+  # - label: ":k8s:"
+  #   command: .buildkite/verify-label.sh
+  #   agents: { queue: standard }
+  #
+  # - label: ":k8s:"
+  #   command: .buildkite/verify-rbac-labels.sh
+  #   agents: { queue: standard }
+  #
+  # - label: ":git: :sleuth_or_spy:"
+  #   command: .buildkite/verify-release/verify-release.sh
+  #   agents: { queue: standard }
+  #
+  # - label: ":k8s: :sleuth_or_spy:"
+  #   command: .buildkite/check-image-names.sh
+  #   agents: { queue: standard }
+  #
+  # - label: ":k8s:"
+  #   command: .buildkite/verify-overlays.sh
+  #   agents: { queue: standard }
+  #
+  # - label: "Release: test"
+  #   if: "build.branch =~ /^wip_/"
+  #   command: |
+  #     wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+  #     tar zxf sg-rfc795.tar.gz
+  #     chmod +x ./sg-rfc795
+  #
+  #     ./sg-rfc795 release run test --workdir=. --config-from-commit
+  #
+  # - wait
+  #
+  # - label: "Release: finalize"
+  #   if: "build.branch =~ /^wip_/"
+  #   command: |
+  #     wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+  #     tar zxf sg-rfc795.tar.gz
+  #     chmod +x ./sg-rfc795
+  #
+  #     ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
+  # - label: "Promote to public: finalize"
+  #   if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
+  #   command: |
+  #     wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+  #     tar zxf sg-rfc795.tar.gz
+  #     chmod +x ./sg-rfc795
+  #
+  #     ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,57 +1,46 @@
 steps:
-  - label: 'Showing sg help'
-    command: sg --help
+  - label: ":k8s:"
+    command: .buildkite/verify-yaml.sh
+    agents: { queue: standard }
+
+  - label: ":k8s:"
+    command: .buildkite/verify-label.sh
+    agents: { queue: standard }
+
+  - label: ":k8s:"
+    command: .buildkite/verify-rbac-labels.sh
+    agents: { queue: standard }
+
+  - label: ":git: :sleuth_or_spy:"
+    command: .buildkite/verify-release/verify-release.sh
+    agents: { queue: standard }
+
+  - label: ":k8s: :sleuth_or_spy:"
+    command: .buildkite/check-image-names.sh
+    agents: { queue: standard }
+
+  - label: ":k8s:"
+    command: .buildkite/verify-overlays.sh
+    agents: { queue: standard }
+
+  - label: "Release: test"
+    if: "build.branch =~ /^wip_/"
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
+    command: |
+      sg release run test --workdir=. --config-from-commit
 
-  # - label: ":k8s:"
-  #   command: .buildkite/verify-yaml.sh
-  #   agents: { queue: standard }
-  #
-  # - label: ":k8s:"
-  #   command: .buildkite/verify-label.sh
-  #   agents: { queue: standard }
-  #
-  # - label: ":k8s:"
-  #   command: .buildkite/verify-rbac-labels.sh
-  #   agents: { queue: standard }
-  #
-  # - label: ":git: :sleuth_or_spy:"
-  #   command: .buildkite/verify-release/verify-release.sh
-  #   agents: { queue: standard }
-  #
-  # - label: ":k8s: :sleuth_or_spy:"
-  #   command: .buildkite/check-image-names.sh
-  #   agents: { queue: standard }
-  #
-  # - label: ":k8s:"
-  #   command: .buildkite/verify-overlays.sh
-  #   agents: { queue: standard }
-  #
-  # - label: "Release: test"
-  #   if: "build.branch =~ /^wip_/"
-  #   command: |
-  #     wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
-  #     tar zxf sg-rfc795.tar.gz
-  #     chmod +x ./sg-rfc795
-  #
-  #     ./sg-rfc795 release run test --workdir=. --config-from-commit
-  #
-  # - wait
-  #
-  # - label: "Release: finalize"
-  #   if: "build.branch =~ /^wip_/"
-  #   command: |
-  #     wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
-  #     tar zxf sg-rfc795.tar.gz
-  #     chmod +x ./sg-rfc795
-  #
-  #     ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
-  # - label: "Promote to public: finalize"
-  #   if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
-  #   command: |
-  #     wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
-  #     tar zxf sg-rfc795.tar.gz
-  #     chmod +x ./sg-rfc795
-  #
-  #     ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit
+  - wait
+
+  - label: "Release: finalize"
+    if: "build.branch =~ /^wip_/"
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
+    command: |
+      sg release run internal finalize --workdir=. --config-from-commit
+  - label: "Promote to public: finalize"
+    if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
+    command: |
+      sg release run promote-to-public finalize --workdir=. --config-from-commit

--- a/release.yaml
+++ b/release.yaml
@@ -22,7 +22,7 @@ internal:
       patch:
         - name: "sg ops (base)"
           cmd: |
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
@@ -31,7 +31,7 @@ internal:
               base/
         - name: "sg ops (executors)"
           cmd: |
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
@@ -60,7 +60,7 @@ internal:
       minor:
         - name: "sg ops (base)"
           cmd: |
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
@@ -69,7 +69,7 @@ internal:
               base/
         - name: "sg ops (executors)"
           cmd: |
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
@@ -98,7 +98,7 @@ internal:
       major:
         - name: "sg ops (base)"
           cmd: |
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
@@ -107,7 +107,7 @@ internal:
               base/
         - name: "sg ops (executors)"
           cmd: |
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
@@ -157,7 +157,7 @@ promoteToPublic:
           git checkout origin/wip-release-{{version}}
       - name: "sg ops"
         cmd: |
-          sg-rfc795 ops update-images \
+          sg ops update-images \
             --kind k8s \
             --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
             --docker-username=$DOCKER_USERNAME \
@@ -166,7 +166,7 @@ promoteToPublic:
             base/
       - name: "sg ops (executors)"
         cmd: |
-          sg-rfc795 ops update-images \
+          sg ops update-images \
             --kind k8s \
             --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
             --docker-username=$DOCKER_USERNAME \


### PR DESCRIPTION
Remove references to custom built `sg` now that new release process landed on main.

## Description

<!-- description here -->

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

The failure is just before I noticed another bug, which got fixed in https://github.com/sourcegraph/sourcegraph/pull/61191

![CleanShot 2024-03-15 at 18 26 45@2x](https://github.com/sourcegraph/deploy-sourcegraph-k8s/assets/10151/6ef8f65f-015a-4004-9876-f432e181baf4)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
