### PR TITLE
Release update + tooling QA

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -23,6 +23,23 @@ steps:
     command: .buildkite/verify-overlays.sh
     agents: { queue: standard }
 
+  # Please keep in mind that the release manifest uses specific branch names when creating releases.
+  # Therefore, if you update them, or if you decide to change how we detect what kind of build we're dealing
+  # with, please update this file as well.
+  - label: "(internal) Release: test"
+    if: build.branch =~ /^internal\/release-.*/
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
+    command: |
+      sg release run test --workdir=. --config-from-commit/release-.*/
+
+  - label: "(promote) Release: test"
+    if: build.branch =~ /^promote\/release-.*/
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
+    command: |
+      sg release run test --workdir=. --config-from-commit
+
   - label: "Release: test"
     if: "build.branch =~ /^wip_/"
     plugins:
@@ -32,14 +49,15 @@ steps:
 
   - wait
 
-  - label: "Release: finalize"
-    if: "build.branch =~ /^wip_/"
+  - label: "(internal) Release: finalize"
+    if: build.branch =~ /^internal\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
       sg release run internal finalize --workdir=. --config-from-commit
-  - label: "Promote to public: finalize"
-    if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
+
+  - label: "(promote) Release: finalize"
+    if: build.branch =~ /^promote\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -31,7 +31,7 @@ steps:
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
-      sg release run test --workdir=. --config-from-commit/release-.*/
+      sg release run test --workdir=. --config-from-commit
 
   - label: "(promote) Release: test"
     if: build.branch =~ /^promote\/release-.*/

--- a/.tool-versions
+++ b/.tool-versions
@@ -6,3 +6,4 @@ kustomize 4.5.7
 shfmt 3.1.0
 nodejs 20.8.1
 python system
+github-cli 2.46.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -7,4 +7,3 @@ shfmt 3.1.0
 nodejs 20.8.1
 github-cli 2.46.0
 python system
-

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,5 +5,6 @@ fd 7.4.0
 kustomize 4.5.7
 shfmt 3.1.0
 nodejs 20.8.1
-python system
 github-cli 2.46.0
+python system
+

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ The contents of this repository are open-source licensed. However, it makes refe
 For product and [pricing](https://about.sourcegraph.com/pricing/) information, visit
 [about.sourcegraph.com](https://about.sourcegraph.com) or [contact
 us](https://about.sourcegraph.com/contact/sales) for more information.
+
+---
+
+### Contributing 
+
+#### Releasing 
+
+Please see the [documentation](https://go/releases).

--- a/release.yaml
+++ b/release.yaml
@@ -257,9 +257,7 @@ promoteToPublic:
           set -eu
 
           # Branches
-          git tag wip_{{version}}
           internal_branch="internal/release-{{version}}"
-          git push origin ${branch} --tags
           promote_branch="promote/release-{{version}}"
           release_branch="release-{{version}}"
 

--- a/release.yaml
+++ b/release.yaml
@@ -177,7 +177,6 @@ internal:
           branch="internal/release-{{version}}"
 
           # Post a comment on the PR.
-          git checkout -
           cat << EOF | gh pr comment "$branch" --body-file -
           - :green_circle: Internal release is ready for promotion!
           - :warning: Do not close/merge that pull request or delete the associated branch if you intend to promote it.

--- a/release.yaml
+++ b/release.yaml
@@ -230,6 +230,7 @@ promoteToPublic:
       - name: "git:commit"
         cmd: |
           set -eu
+          branch="promote/release-{{version}}"
           find . -name "*.yaml" | xargs git add
           find . -name "*.yml" | xargs git add
 

--- a/release.yaml
+++ b/release.yaml
@@ -264,11 +264,11 @@ promoteToPublic:
           # Create the final branch holding the tagged commit
           git checkout "${promote_branch}"
           git switch -c "${release_branch}"
-          git tag QA-{{version}}
+          git tag {{version}}
           git push origin ${release_branch} --tags
 
           # Web URL to the tag
-          tag_url="https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/QA-{{version}}"
+          tag_url="https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/{{version}}"
 
           # Annotate PRs 
           cat << EOF | gh pr comment "$internal_branch" --body-file -
@@ -285,5 +285,5 @@ promoteToPublic:
 
           # Annotate build
           cat << EOF | buildkite-agent annotate --style info
-          Promoted release is **publicly available** through a git tag at [\`QA-{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/QA-{{version}}).
+          Promoted release is **publicly available** through a git tag at [\`{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/{{version}}).
           EOF

--- a/release.yaml
+++ b/release.yaml
@@ -178,7 +178,7 @@ internal:
           # Post a comment on the PR.
           cat << EOF | gh pr comment "$branch" --body-file -
           - :green_circle: Internal release is ready for promotion!
-          - :warning: Do not close/merge that pull request or delete the associated branch if you intend to promote it.
+          - :warning: Do not close/merge the pull request or delete the associated branch if you intend to promote it.
           EOF
           # Post an annotation.
           cat << EOF | buildkite-agent annotate --style info
@@ -273,7 +273,7 @@ promoteToPublic:
           cat << EOF | gh pr comment "$internal_branch" --body-file -
           - :green_circle: Release has been promoted, see tag: $tag_url.
           - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (i.e. \`$release_branch\`).
-          - :arrow_right: You can safely close that PR and delete its a associated branch.
+          - :arrow_right: You can safely close the PR and delete its a associated branch.
           EOF
 
           cat << EOF | gh pr comment "$promote_branch" --body-file -

--- a/release.yaml
+++ b/release.yaml
@@ -69,7 +69,7 @@ internal:
               --fill \
               --draft \
               --title "(internal) release_patch: build {{version}}" \
-              --body "Test plan: automated release PR, CI will perform additional checks" 
+              --body "Test plan: automated release PR, CI will perform additional checks"
             echo "🚢 Please check the associated CI build to ensure the process completed".
       minor:
         - name: "sg ops (base)"
@@ -84,7 +84,7 @@ internal:
               base/
         - name: "sg ops (executors)"
           cmd: |
-            set -eu 
+            set -eu
             sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
@@ -116,7 +116,7 @@ internal:
               --fill \
               --draft \
               --title "(internal) release_minor: build {{version}}" \
-              --body "Test plan: automated release PR, CI will perform additional checks" 
+              --body "Test plan: automated release PR, CI will perform additional checks"
             echo "🚢 Please check the associated CI build to ensure the process completed".
       major:
         - name: "sg ops (base)"
@@ -144,7 +144,6 @@ internal:
             set -eu
             branch="internal/release-{{version}}"
             echo "Creating branch $branch"
-            release_branch="wip_{{version}}"
             git checkout -b "$branch"
         - name: "git:commit"
           cmd: |
@@ -166,7 +165,7 @@ internal:
               --fill \
               --draft \
               --title "(internal) release_major: build {{version}}" \
-              --body "Test plan: automated release PR, CI will perform additional checks" 
+              --body "Test plan: automated release PR, CI will perform additional checks"
             echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:
     steps:
@@ -198,8 +197,8 @@ promoteToPublic:
       - name: "git"
         cmd: |
           set -eu
-          echo "Checking out origin/wip-release-{{version}}"
           branch="internal/release-{{version}}"
+          echo "Checking out origin/${branch}"
           git fetch origin "${branch}"
           git switch "${branch}"
       - name: "sg ops"
@@ -270,7 +269,7 @@ promoteToPublic:
           # Web URL to the tag
           tag_url="https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/{{version}}"
 
-          # Annotate PRs 
+          # Annotate PRs
           cat << EOF | gh pr comment "$internal_branch" --body-file -
           - :green_circle: Release has been promoted, see tag: $tag_url.
           - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (i.e. \`$release_branch\`).

--- a/release.yaml
+++ b/release.yaml
@@ -17,11 +17,15 @@ requirements:
     env: DOCKER_PASSWORD
 
 internal:
+  # Please keep in mind that the CI pipeline uses the branch names defined below when creating releases.
+  # Therefore, if you update them, or if you decide to change how we detect what kind of build we're dealing
+  # with, please update this file as well.
   create:
     steps:
       patch:
         - name: "sg ops (base)"
           cmd: |
+            set -eu
             sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
@@ -31,6 +35,7 @@ internal:
               base/
         - name: "sg ops (executors)"
           cmd: |
+            set -eu
             sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
@@ -40,26 +45,36 @@ internal:
               components/executors/
         - name: "git:branch"
           cmd: |
-            echo "Creating branch wip_{{version}}"
-            release_branch="wip_{{version}}"
-            git checkout -b $release_branch
+            set -eu
+            branch="internal/release-{{version}}"
+            echo "Creating branch $branch"
+            git checkout -b $branch
         - name: "git:commit"
           cmd: |
             find . -name "*.yaml" | xargs git add
             find . -name "*.yml" | xargs git add
+
             # Careful with the quoting for the config, using double quotes will lead
             # to the shell dropping out all quotes from the json, leading to failed
             # parsing.
             git commit -m "release_patch: {{version}}" -m '{{config}}'
         - name: "git:push"
           cmd: |
-            git push origin wip_{{version}}
-        - name: "gh cli"
+            branch="internal/release-{{version}}"
+            git push origin "$branch"
+        - name: "github:pr"
           cmd: |
-            gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"  # -l "wip_release"
+            set -eu
+            gh pr create \
+              --fill \
+              --draft \
+              --title "(internal) release_patch: build {{version}}" \
+              --body "Test plan: automated release PR, CI will perform additional checks" 
+            echo "🚢 Please check the associated CI build to ensure the process completed".
       minor:
         - name: "sg ops (base)"
           cmd: |
+            set -eu
             sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
@@ -69,6 +84,7 @@ internal:
               base/
         - name: "sg ops (executors)"
           cmd: |
+            set -eu 
             sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
@@ -78,9 +94,10 @@ internal:
               components/executors/
         - name: "git:branch"
           cmd: |
-            echo "Creating branch wip_{{version}}"
-            release_branch="wip_{{version}}"
-            git checkout -b $release_branch
+            set -eu
+            branch="internal/release-{{version}}"
+            echo "Creating branch $branch"
+            git checkout -b "$branch"
         - name: "git:commit"
           cmd: |
             find . -name "*.yaml" | xargs git add
@@ -91,13 +108,20 @@ internal:
             git commit -m "release_minor: {{version}}" -m '{{config}}'
         - name: "git:push"
           cmd: |
-            git push origin wip_{{version}}
-        - name: "gh cli"
+            branch="internal/release-{{version}}"
+            git push origin "$branch"
+        - name: "github:pr"
           cmd: |
-            gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"  # -l "wip_release"
+            gh pr create \
+              --fill \
+              --draft \
+              --title "(internal) release_minor: build {{version}}" \
+              --body "Test plan: automated release PR, CI will perform additional checks" 
+            echo "🚢 Please check the associated CI build to ensure the process completed".
       major:
         - name: "sg ops (base)"
           cmd: |
+            set -eu
             sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
@@ -107,6 +131,7 @@ internal:
               base/
         - name: "sg ops (executors)"
           cmd: |
+            set -eu
             sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
@@ -116,30 +141,51 @@ internal:
               components/executors/
         - name: "git:branch"
           cmd: |
-            echo "Creating branch wip_{{version}}"
+            set -eu
+            branch="internal/release-{{version}}"
+            echo "Creating branch $branch"
             release_branch="wip_{{version}}"
-            git checkout -b $release_branch
+            git checkout -b "$branch"
         - name: "git:commit"
           cmd: |
+            set -eu
             find . -name "*.yaml" | xargs git add
             find . -name "*.yml" | xargs git add
             # Careful with the quoting for the config, using double quotes will lead
             # to the shell dropping out all quotes from the json, leading to failed
             # parsing.
-            git commit -m "release_patch: {{version}}" -m '{{config}}'
+            git commit -m "release_major: {{version}}" -m '{{config}}'
         - name: "git:push"
           cmd: |
-            git push origin wip_{{version}}
-        - name: "gh cli"
+            branch="internal/release-{{version}}"
+            git push origin "$branch"
+        - name: "github:pr"
           cmd: |
-            gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"  # -l "wip_release"
+            set -eu
+            gh pr create \
+              --fill \
+              --draft \
+              --title "(internal) release_major: build {{version}}" \
+              --body "Test plan: automated release PR, CI will perform additional checks" 
+            echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:
     steps:
-      - name: "git"
+      - name: "notifications"
         cmd: |
-          git checkout -b wip-release-{{version}}
-          git push origin wip-release-{{version}}
+          set -eu
+
+          branch="internal/release-{{version}}"
+
+          # Post a comment on the PR.
           git checkout -
+          cat << EOF | gh pr comment "$branch" --body-file -
+          - :green_circle: Internal release is ready for promotion!
+          - :warning: Do not close/merge that pull request or delete the associated branch if you intend to promote it.
+          EOF
+          # Post an annotation.
+          cat << EOF | buildkite-agent annotate --style info
+          Internal release is ready for promotion under the branch [\`$branch\`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$branch).
+          EOF
 
 test:
   steps:
@@ -152,11 +198,14 @@ promoteToPublic:
     steps:
       - name: "git"
         cmd: |
+          set -eu
           echo "Checking out origin/wip-release-{{version}}"
-          git fetch origin
-          git checkout origin/wip-release-{{version}}
+          branch="internal/release-{{version}}"
+          git fetch origin "${branch}"
+          git switch "${branch}"
       - name: "sg ops"
         cmd: |
+          set -eu
           sg ops update-images \
             --kind k8s \
             --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
@@ -166,6 +215,7 @@ promoteToPublic:
             base/
       - name: "sg ops (executors)"
         cmd: |
+          set -eu
           sg ops update-images \
             --kind k8s \
             --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
@@ -175,27 +225,67 @@ promoteToPublic:
             components/executors/
       - name: "git:branch"
         cmd: |
-          echo "Creating branch promote-release_{{version}}"
-          branch="promote-release_{{version}}"
-          git checkout -b $branch
+          set -eu
+          branch="promote/release-{{version}}"
+          git switch -c "${branch}"
       - name: "git:commit"
         cmd: |
+          set -eu
           find . -name "*.yaml" | xargs git add
           find . -name "*.yml" | xargs git add
+
           # Careful with the quoting for the config, using double quotes will lead
           # to the shell dropping out all quotes from the json, leading to failed
           # parsing.
-          git commit -m "promote_release: {{version}}" -m '{{config}}'
-      - name: "github"
+          git commit -am 'promote-release: {{version}}' -m '{{config}}'
+          git push origin "${branch}"
+      - name: "github:pr"
         cmd: |
-          git push origin promote-release_{{version}}
-          gh pr create -f -t "PRETEND PROMOTE RELEASE WIP: promote-release: build {{version}}" --base wip-release-{{version}} --body "Test plan: automated release PR, CI will perform additional checks"
+          set -eu
+          internal_branch="internal/release-{{version}}"
+          gh pr create \
+            --fill \
+            --draft \
+            --base "$internal_branch" \
+            --title "(promote) release: build {{version}}" \
+            --body "Test plan: automated release PR, CI will perform additional checks"
+          echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:
-    # These steps should only really run once the pr created in the create step is merged
     steps:
       - name: git:tag
         cmd: |
-          branch="wip-release-{{version}}"
-          git checkout ${branch}
-          git tag {{version}}
+          set -eu
+
+          # Branches
+          git tag wip_{{version}}
+          internal_branch="internal/release-{{version}}"
           git push origin ${branch} --tags
+          promote_branch="promote/release-{{version}}"
+          release_branch="release-{{version}}"
+
+          # Create the final branch holding the tagged commit
+          git checkout "${promote_branch}"
+          git switch -c "${release_branch}"
+          git tag QA-{{version}}
+          git push origin ${release_branch} --tags
+
+          # Web URL to the tag
+          tag_url="https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/QA-{{version}}"
+
+          # Annotate PRs 
+          cat << EOF | gh pr comment "$internal_branch" --body-file -
+          - :green_circle: Release has been promoted, see tag: $tag_url.
+          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (i.e. \`$release_branch\`).
+          - :arrow_right: You can safely close that PR and delete its a associated branch.
+          EOF
+
+          cat << EOF | gh pr comment "$promote_branch" --body-file -
+          - :green_circle: Release has been promoted, see tag: $tag_url.
+          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (i.e. \`$release_branch\`).
+          - :arrow_right: You can safely close that PR and delete its a associated branch.
+          EOF
+
+          # Annotate build
+          cat << EOF | buildkite-agent annotate --style info
+          Promoted release is **publicly available** through a git tag at [\`QA-{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/QA-{{version}}).
+          EOF


### PR DESCRIPTION
Follow-up of https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/1008, see the description over there, it's exactly the same logic. 


## Description

<!-- description here -->

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

- QA for the changes in that PR: same as the docker variant, mutiple runs
  - https://buildkite.com/sourcegraph/deploy-sourcegraph-k8s/builds/318
  - https://buildkite.com/sourcegraph/deploy-sourcegraph-k8s/builds/315
  - tagging ![CleanShot 2024-03-24 at 12 55 58@2x](https://github.com/sourcegraph/deploy-sourcegraph-k8s/assets/10151/8c72ad1a-85af-4c95-9efe-9d3b6a740d85)

  
- QA for the result: compared the PR file by file against https://github.com/sourcegraph/deploy-sourcegraph-k8s/pull/101/files 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
