### PR TITLE
release: use docker hub registry for public releases

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -206,7 +206,7 @@ promoteToPublic:
           set -eu
           sg ops update-images \
             --kind k8s \
-            --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+            --registry index.docker.io/sourcegraph \
             --docker-username=$DOCKER_USERNAME \
             --docker-password=$DOCKER_PASSWORD \
             --pin-tag {{inputs.server.tag}} \
@@ -216,7 +216,7 @@ promoteToPublic:
           set -eu
           sg ops update-images \
             --kind k8s \
-            --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+            --registry index.docker.io/sourcegraph \
             --docker-username=$DOCKER_USERNAME \
             --docker-password=$DOCKER_PASSWORD \
             --pin-tag {{inputs.server.tag}} \


### PR DESCRIPTION
use the public docker hub registry for public releases

## Test plan
CI and executed `sg ops update-images` locally (with the fix from https://github.com/sourcegraph/sourcegraph/pull/61592)
