### PR TITLE
release: disable promotion criteria validation

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -278,25 +278,25 @@ promoteToPublic:
           echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:
     steps:
-      - name: 'validate promotion criteria'
-        cmd: |
-          echo "validating promotion criteria"
-          body=$(wget --content-on-error -O- --header="Content-Type: application/json" "https://releaseregistry.sourcegraph.com/v1/releases/k8s/{{version}}")
-          exit_code=$?
+      # - name: 'validate promotion criteria'
+      #   cmd: |
+      #     echo "validating promotion criteria"
+      #     body=$(wget --content-on-error -O- --header="Content-Type: application/json" "https://releaseregistry.sourcegraph.com/v1/releases/k8s/{{version}}")
+      #     exit_code=$?
 
-          if [ $exit_code != 0 ]; then
-            echo "❌ Failed to fetch release on release registry, got:"
-            echo "--- raw body ---"
-            echo $body
-            echo "--- raw body ---"
-            exit $exit_code
-          fi
+      #     if [ $exit_code != 0 ]; then
+      #       echo "❌ Failed to fetch release on release registry, got:"
+      #       echo "--- raw body ---"
+      #       echo $body
+      #       echo "--- raw body ---"
+      #       exit $exit_code
+      #     fi
 
-          is_development=$(echo "$body" | jq -r '.is_development')
-          if [ "$is_development" = "true" ]; then
-            echo "cannot promote a development release"
-            exit 1
-          fi
+      #     is_development=$(echo "$body" | jq -r '.is_development')
+      #     if [ "$is_development" = "true" ]; then
+      #       echo "cannot promote a development release"
+      #       exit 1
+      #     fi
       - name: git:tag
         cmd: |
           set -eu


### PR DESCRIPTION
## Description

<!-- description here -->

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

The introduction of the `is_development` field makes this logic wrong as we can now have multiple versions of a product in the release registry, albeit with different `is_development` values. 

Plan is to fix this after the current release.
