### PR TITLE
Pass tokens for uploading SCIP indexes

### DIFF
--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -17,5 +17,13 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Generate SCIP data
         run: scip-go
-      - name: Upload SCIP data
-        run: src code-intel upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SCIP to Cloud
+        run: src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        env:
+          SRC_ENDPOINT: https://sourcegraph.com/
+          SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
+      - name: Upload SCIP to S2
+        run: src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        env:
+          SRC_ENDPOINT: https://sourcegraph.sourcegraph.com/
+          SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_S2 }}


### PR DESCRIPTION
## Description

Tokens are needed for SCIP uploads now

Fixes GRAPH-599

## Checklist

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

n/a