### PR TITLE
fix redis startup

### DIFF
--- a/base/sourcegraph/redis/redis-cache.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-cache.Deployment.yaml
@@ -37,8 +37,22 @@ spec:
               name: redis
           readinessProbe:
             initialDelaySeconds: 5
-            tcpSocket:
-              port: redis
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  #!/bin/bash
+                  if [ -f /etc/redis/redis.conf ]; then
+                    export REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                  fi
+                  response=$(
+                    redis-cli ping
+                  )
+                  if [ "$response" != "PONG" ]; then
+                    echo "$response"
+                    exit 1
+                  fi
           resources:
             limits:
               cpu: "1"

--- a/base/sourcegraph/redis/redis-store.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-store.Deployment.yaml
@@ -36,8 +36,22 @@ spec:
               name: redis
           readinessProbe:
             initialDelaySeconds: 5
-            tcpSocket:
-              port: redis
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    #!/bin/bash
+                    if [ -f /etc/redis/redis.conf ]; then
+                      export REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                    fi
+                    response=$(
+                      redis-cli ping
+                    )
+                    if [ "$response" != "PONG" ]; then
+                      echo "$response"
+                      exit 1
+                    fi
           resources:
             limits:
               cpu: "1"

--- a/base/sourcegraph/redis/redis-store.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-store.Deployment.yaml
@@ -36,22 +36,22 @@ spec:
               name: redis
           readinessProbe:
             initialDelaySeconds: 5
-              exec:
-                command:
-                  - /bin/sh
-                  - -c
-                  - |
-                    #!/bin/bash
-                    if [ -f /etc/redis/redis.conf ]; then
-                      export REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
-                    fi
-                    response=$(
-                      redis-cli ping
-                    )
-                    if [ "$response" != "PONG" ]; then
-                      echo "$response"
-                      exit 1
-                    fi
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  #!/bin/bash
+                  if [ -f /etc/redis/redis.conf ]; then
+                    export REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                  fi
+                  response=$(
+                    redis-cli ping
+                  )
+                  if [ "$response" != "PONG" ]; then
+                    echo "$response"
+                    exit 1
+                  fi
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
## Description
fix redis startup
mirror: https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/458

<!-- description here -->

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan
Deploy locally

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
