### PR TITLE
fix the readiness probe fix, to correctly handle for passwords

### DIFF
--- a/base/sourcegraph/redis/redis-cache.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-cache.Deployment.yaml
@@ -38,22 +38,23 @@ spec:
           readinessProbe:
             initialDelaySeconds: 10
             timeoutSeconds: 5
-            command:
-              - /bin/sh
-              - -c
-              - |
-                #!/bin/bash
-                PASS_CHECK=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
-                if [ ! -z "$PASS_CHECK" ]; then
-                  export REDISCLI_AUTH="$PASS_CHECK"
-                fi
-                response=$(
-                  redis-cli ping
-                )
-                if [ "$response" != "PONG" ]; then
-                  echo "$response"
-                  exit 1
-                fi
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  #!/bin/bash
+                  PASS_CHECK=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                  if [ ! -z "$PASS_CHECK" ]; then
+                    export REDISCLI_AUTH="$PASS_CHECK"
+                  fi
+                  response=$(
+                    redis-cli ping
+                  )
+                  if [ "$response" != "PONG" ]; then
+                    echo "$response"
+                    exit 1
+                  fi
           resources:
             limits:
               cpu: "1"

--- a/base/sourcegraph/redis/redis-cache.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-cache.Deployment.yaml
@@ -36,9 +36,24 @@ spec:
             - containerPort: 6379
               name: redis
           readinessProbe:
-            initialDelaySeconds: 5
-            tcpSocket:
-              port: redis
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            command:
+              - /bin/sh
+              - -c
+              - |
+                #!/bin/bash
+                PASS_CHECK=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                if [ ! -z "$PASS_CHECK" ]; then
+                  export REDISCLI_AUTH="$PASS_CHECK"
+                fi
+                response=$(
+                  redis-cli ping
+                )
+                if [ "$response" != "PONG" ]; then
+                  echo "$response"
+                  exit 1
+                fi
           resources:
             limits:
               cpu: "1"

--- a/base/sourcegraph/redis/redis-store.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-store.Deployment.yaml
@@ -35,9 +35,24 @@ spec:
             - containerPort: 6379
               name: redis
           readinessProbe:
-            initialDelaySeconds: 5
-            tcpSocket:
-              port: redis
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            command:
+              - /bin/sh
+              - -c
+              - |
+                #!/bin/bash
+                PASS_CHECK=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                if [ ! -z "$PASS_CHECK" ]; then
+                  export REDISCLI_AUTH="$PASS_CHECK"
+                fi
+                response=$(
+                  redis-cli ping
+                )
+                if [ "$response" != "PONG" ]; then
+                  echo "$response"
+                  exit 1
+                fi
           resources:
             limits:
               cpu: "1"

--- a/base/sourcegraph/redis/redis-store.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-store.Deployment.yaml
@@ -37,22 +37,23 @@ spec:
           readinessProbe:
             initialDelaySeconds: 10
             timeoutSeconds: 5
-            command:
-              - /bin/sh
-              - -c
-              - |
-                #!/bin/bash
-                PASS_CHECK=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
-                if [ ! -z "$PASS_CHECK" ]; then
-                  export REDISCLI_AUTH="$PASS_CHECK"
-                fi
-                response=$(
-                  redis-cli ping
-                )
-                if [ "$response" != "PONG" ]; then
-                  echo "$response"
-                  exit 1
-                fi
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  #!/bin/bash
+                  PASS_CHECK=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                  if [ ! -z "$PASS_CHECK" ]; then
+                    export REDISCLI_AUTH="$PASS_CHECK"
+                  fi
+                  response=$(
+                    redis-cli ping
+                  )
+                  if [ "$response" != "PONG" ]; then
+                    echo "$response"
+                    exit 1
+                  fi
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
## Description
Follow fix after causing incident on dotcom from handling for no password incorrectly (https://sourcegraph.slack.com/archives/C074VSHMQSK/p1716835338964249)

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan
Tested on kind cluster with both password supplied and not
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
