### PR TITLE
fix(otel): update jaeger config

### DIFF
--- a/base/monitoring/jaeger/jaeger-collector.Service.yaml
+++ b/base/monitoring/jaeger/jaeger-collector.Service.yaml
@@ -15,13 +15,13 @@ spec:
     protocol: TCP
     targetPort: 14267
   - name: jaeger-collector-http
-    port: 14268
+    port: 4321
     protocol: TCP
-    targetPort: 14268
+    targetPort: 4321
   - name: jaeger-collector-grpc
-    port: 14250
+    port: 4320
     protocol: TCP
-    targetPort: 14250
+    targetPort: 4320
   selector:
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: all-in-one

--- a/base/monitoring/jaeger/jaeger.Deployment.yaml
+++ b/base/monitoring/jaeger/jaeger.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: jaeger
           image: index.docker.io/sourcegraph/jaeger-all-in-one:216430_2023-05-02_5.0-3cc9006de32c@sha256:ec73cff6ea398d96241a9451634fc83682292b0175cc63c09f1f866cf03beb8d
-          args: ["--memory.max-traces=20000"]
+          args: ["--memory.max-traces=20000", "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json", "--collector.otlp.enabled"]
           ports:
             - containerPort: 5775
               protocol: UDP
@@ -43,7 +43,9 @@ spec:
               protocol: TCP
             - containerPort: 16686
               protocol: TCP
-            - containerPort: 14250
+            - containerPort: 4320
+              protocol: TCP
+            - containerPort: 4321
               protocol: TCP
           readinessProbe:
             httpGet:


### PR DESCRIPTION
## Description

<!-- description here -->

Resolves [REL-170](https://linear.app/sourcegraph/issue/REL-170/cve-2024-36129-deploy-sourcegraph-k8s)

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [x] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Manual testing
