### PR TITLE
release: cherrypick 5.6.185 release

### DIFF
--- a/base/monitoring/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/monitoring/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
         - name: cadvisor
-          image: index.docker.io/sourcegraph/cadvisor:216430_2023-05-02_5.0-3cc9006de32c@sha256:6ea7f53807e4a559ee825ba2a0c4c3b3f721275f0b5ce0e979f4fdad8a4e478a
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/cadvisor:5.6.185@sha256:36891194a78fdc6bb81c0a146e1782151280591e71c151d7e7e444d6f26da020
           args:
             # Kubernetes-specific flags below (other flags are baked into the Docker image)
             #

--- a/base/monitoring/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/monitoring/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
         - name: cadvisor
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/cadvisor:5.6.185@sha256:36891194a78fdc6bb81c0a146e1782151280591e71c151d7e7e444d6f26da020
+          image: index.docker.io/sourcegraph/cadvisor:5.6.185@sha256:91fef9d8f036927f6218fb507be07cab003e9412ff8aa081416ebe0e9cd77b7b
           args:
             # Kubernetes-specific flags below (other flags are baked into the Docker image)
             #

--- a/base/monitoring/grafana/grafana.StatefulSet.yaml
+++ b/base/monitoring/grafana/grafana.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/grafana:5.6.185@sha256:d3120ad85e6b16a0aee1a2057d0a6b709a806280f1c05548fba5ba0d4ac25e4b
+          image: index.docker.io/sourcegraph/grafana:5.6.185@sha256:0a8cef20bed768048074d39802703963f1b5e1a0907aa7f692867701de75ca60
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 3370

--- a/base/monitoring/grafana/grafana.StatefulSet.yaml
+++ b/base/monitoring/grafana/grafana.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: index.docker.io/sourcegraph/grafana:216430_2023-05-02_5.0-3cc9006de32c@sha256:63baeadda6d33195ccd7d742670e500a80bacace3ed5cf0eb7d3a6c276ef7c34
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/grafana:5.6.185@sha256:d3120ad85e6b16a0aee1a2057d0a6b709a806280f1c05548fba5ba0d4ac25e4b
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 3370

--- a/base/monitoring/jaeger/jaeger.Deployment.yaml
+++ b/base/monitoring/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: jaeger
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/jaeger-all-in-one:5.6.185@sha256:29f1cdc2bd0f51b4fa906aa8b056a7ff5aab2ba6ab82f0d52a55aad057cf8357
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:5.6.185@sha256:c0411e4910926c92896b3ec6cf4b2f5dc0d6c99cb7433035406f57b51cdab2ef
           args: ["--memory.max-traces=20000", "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json", "--collector.otlp.enabled"]
           ports:
             - containerPort: 5775

--- a/base/monitoring/jaeger/jaeger.Deployment.yaml
+++ b/base/monitoring/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:216430_2023-05-02_5.0-3cc9006de32c@sha256:ec73cff6ea398d96241a9451634fc83682292b0175cc63c09f1f866cf03beb8d
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/jaeger-all-in-one:5.6.185@sha256:29f1cdc2bd0f51b4fa906aa8b056a7ff5aab2ba6ab82f0d52a55aad057cf8357
           args: ["--memory.max-traces=20000", "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json", "--collector.otlp.enabled"]
           ports:
             - containerPort: 5775

--- a/base/monitoring/node-exporter/node-exporter.DaemonSet.yaml
+++ b/base/monitoring/node-exporter/node-exporter.DaemonSet.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: node-exporter
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/node-exporter:5.6.185@sha256:15ce6fbd5500b4cd4f1b7b3f70329d1809ff368fa1a80fc63a3f18de950904bd
+          image: index.docker.io/sourcegraph/node-exporter:5.6.185@sha256:76798c4a14a3d6b67cd062c297e910ea42311d182668ab20dc38e5892f3d7796
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/base/monitoring/node-exporter/node-exporter.DaemonSet.yaml
+++ b/base/monitoring/node-exporter/node-exporter.DaemonSet.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: node-exporter
-          image: index.docker.io/sourcegraph/node-exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:fa8e5700b7762fffe0674e944762f44bb787a7e44d97569fe55348260453bf80
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/node-exporter:5.6.185@sha256:15ce6fbd5500b4cd4f1b7b3f70329d1809ff368fa1a80fc63a3f18de950904bd
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/base/monitoring/otel-collector/otel-agent.DaemonSet.yaml
+++ b/base/monitoring/otel-collector/otel-agent.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: otel-agent
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/opentelemetry-collector:5.6.185@sha256:0324b1fb97d8721c08adf57d056795bf5fdf1821385555aa38bc79d8d13ea4de
+          image: index.docker.io/sourcegraph/opentelemetry-collector:5.6.185@sha256:6d5fdb5bcadc518c2580662f28788b5866a48a848d2551d795221e49e1814452
           command:
             - "/bin/otelcol-sourcegraph"
             - "--config=/etc/otel-agent/config.yaml"

--- a/base/monitoring/otel-collector/otel-agent.DaemonSet.yaml
+++ b/base/monitoring/otel-collector/otel-agent.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: otel-agent
-          image: index.docker.io/sourcegraph/opentelemetry-collector:216430_2023-05-02_5.0-3cc9006de32c@sha256:7783e0a2676813f955f45debc10099ee97e104c42fe27cd315848ba58de86cd4
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/opentelemetry-collector:5.6.185@sha256:0324b1fb97d8721c08adf57d056795bf5fdf1821385555aa38bc79d8d13ea4de
           command:
             - "/bin/otelcol-sourcegraph"
             - "--config=/etc/otel-agent/config.yaml"

--- a/base/monitoring/otel-collector/otel-collector.Deployment.yaml
+++ b/base/monitoring/otel-collector/otel-collector.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: otel-collector
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/opentelemetry-collector:5.6.185@sha256:0324b1fb97d8721c08adf57d056795bf5fdf1821385555aa38bc79d8d13ea4de
+          image: index.docker.io/sourcegraph/opentelemetry-collector:5.6.185@sha256:6d5fdb5bcadc518c2580662f28788b5866a48a848d2551d795221e49e1814452
           command:
             - "/bin/otelcol-sourcegraph"
             # To use a custom configuration, edit otel-collector.ConfigMap.yaml

--- a/base/monitoring/otel-collector/otel-collector.Deployment.yaml
+++ b/base/monitoring/otel-collector/otel-collector.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: otel-collector
-          image: index.docker.io/sourcegraph/opentelemetry-collector:216430_2023-05-02_5.0-3cc9006de32c@sha256:7783e0a2676813f955f45debc10099ee97e104c42fe27cd315848ba58de86cd4
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/opentelemetry-collector:5.6.185@sha256:0324b1fb97d8721c08adf57d056795bf5fdf1821385555aa38bc79d8d13ea4de
           command:
             - "/bin/otelcol-sourcegraph"
             # To use a custom configuration, edit otel-collector.ConfigMap.yaml

--- a/base/monitoring/prometheus/prometheus.Deployment.yaml
+++ b/base/monitoring/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/prometheus:5.6.185@sha256:448d3b9fe4186090403120f28acae174b608be599ecd8e9ce23ffe73e0c7a88f
+          image: index.docker.io/sourcegraph/prometheus:5.6.185@sha256:39cc8f35fb46db19a5e36c3bc05144daada4fdd3dd4d195141e0edeac47f3d9d
           terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: SG_NAMESPACE

--- a/base/monitoring/prometheus/prometheus.Deployment.yaml
+++ b/base/monitoring/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: index.docker.io/sourcegraph/prometheus:216430_2023-05-02_5.0-3cc9006de32c@sha256:da67ba5c797a7b7752cebd6507e903a2726c172c01cab7ce0e7deadff288bab8
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/prometheus:5.6.185@sha256:448d3b9fe4186090403120f28acae174b608be599ecd8e9ce23ffe73e0c7a88f
           terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: SG_NAMESPACE

--- a/base/monitoring/prometheus/prometheus.yml
+++ b/base/monitoring/prometheus/prometheus.yml
@@ -8,7 +8,7 @@ alerting: # Alertmanager configuration
     - static_configs:
         - targets: ["127.0.0.1:9093"]
       path_prefix: /alertmanager
-  # add more alertmanagers here
+      # add more alertmanagers here
 rule_files: # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
   - "/sg_config_prometheus/*_rules.yml"
   - "/sg_prometheus_add_ons/*_rules.yml"
@@ -43,11 +43,7 @@ scrape_configs: # Configure targets to scrape
       - source_labels: [container_label_io_kubernetes_pod_namespace]
         regex: kube-system
         action: drop
-      - source_labels:
-          [
-            container_label_io_kubernetes_container_name,
-            container_label_io_kubernetes_pod_name,
-          ]
+      - source_labels: [container_label_io_kubernetes_container_name, container_label_io_kubernetes_pod_name]
         regex: (.+)
         action: replace
         target_label: name

--- a/base/sourcegraph/blobstore/blobstore.Deployment.yaml
+++ b/base/sourcegraph/blobstore/blobstore.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: blobstore
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/blobstore:5.6.185@sha256:bb7da9a52b99deab8690b77badb010e562c06ea2d35b315c44490e667550a8ad
+          image: index.docker.io/sourcegraph/blobstore:5.6.185@sha256:a8906b3be4c2e954e1ee630e8371bc626712cb3d64793fdbeb3be7df5b6f8713
           livenessProbe:
             httpGet:
               path: /

--- a/base/sourcegraph/blobstore/blobstore.Deployment.yaml
+++ b/base/sourcegraph/blobstore/blobstore.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: blobstore
-          image: index.docker.io/sourcegraph/blobstore:216430_2023-05-02_5.0-3cc9006de32c@sha256:ae1cf541f65441809f3495c037af4f9df1d049defdf0309a65d685f579c7e594
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/blobstore:5.6.185@sha256:bb7da9a52b99deab8690b77badb010e562c06ea2d35b315c44490e667550a8ad
           livenessProbe:
             httpGet:
               path: /

--- a/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       initContainers:
         - name: correct-data-dir-permissions
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/alpine-3.14:5.6.185@sha256:0baf6996d23f8087bfc2b8cf3d0aa53ccc611493b260fca43d3efd886b08a6b7
+          image: index.docker.io/sourcegraph/alpine-3.14:5.6.185@sha256:7b2ecc8f4ed6a0dd1175ad81a3b3f32ebe4b9ab2cea4cbc25aabad5d0da76ab4
           command: ["sh", "-c", "if [ -d /var/lib/postgresql/data/pgdata ]; then chmod 750 /var/lib/postgresql/data/pgdata; fi"]
           volumeMounts:
             - mountPath: /var/lib/postgresql/data/
@@ -45,7 +45,7 @@ spec:
             runAsUser: 70
       containers:
         - name: codeinsights
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/codeinsights-db:5.6.185@sha256:4c1470ad09992a56680584b0ed84ec9ab5af87a7c62b296cfb5145073e7232cb
+          image: index.docker.io/sourcegraph/codeinsights-db:5.6.185@sha256:11730061fdd4bcf70df3beb3be06f1b72ef9f9ef3974900a6a8c67dc270c57f9
           env:
             - name: POSTGRES_DB
               value: postgres
@@ -82,7 +82,7 @@ spec:
               value: postgres://postgres:@localhost:5432/?sslmode=disable
             - name: PG_EXPORTER_EXTEND_QUERY_PATH
               value: /config/code_insights_queries.yaml
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/postgres_exporter:5.6.185@sha256:fa6174e74234748621248b07779e151eeae0be40843a29859d1420528743c178
+          image: index.docker.io/sourcegraph/postgres_exporter:5.6.185@sha256:5654133c53f06d5167ed92dcc978c86dd94b1cab4d818b235318958930cbaae3
           terminationMessagePolicy: FallbackToLogsOnError
           name: pgsql-exporter
           ports:

--- a/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       initContainers:
         - name: correct-data-dir-permissions
-          image: index.docker.io/sourcegraph/alpine-3.14:216430_2023-05-02_5.0-3cc9006de32c@sha256:923c803fb975e905424b347e19839ae0077c0dec6eea0cb71c62acd910e8e9c8
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/alpine-3.14:5.6.185@sha256:0baf6996d23f8087bfc2b8cf3d0aa53ccc611493b260fca43d3efd886b08a6b7
           command: ["sh", "-c", "if [ -d /var/lib/postgresql/data/pgdata ]; then chmod 750 /var/lib/postgresql/data/pgdata; fi"]
           volumeMounts:
             - mountPath: /var/lib/postgresql/data/
@@ -45,7 +45,7 @@ spec:
             runAsUser: 70
       containers:
         - name: codeinsights
-          image: index.docker.io/sourcegraph/codeinsights-db:216430_2023-05-02_5.0-3cc9006de32c@sha256:910e98d4ddb6e5fef28be69f6395e567bbfab3f29f9d340dcdf45e83ca84cdd3
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/codeinsights-db:5.6.185@sha256:4c1470ad09992a56680584b0ed84ec9ab5af87a7c62b296cfb5145073e7232cb
           env:
             - name: POSTGRES_DB
               value: postgres
@@ -82,7 +82,7 @@ spec:
               value: postgres://postgres:@localhost:5432/?sslmode=disable
             - name: PG_EXPORTER_EXTEND_QUERY_PATH
               value: /config/code_insights_queries.yaml
-          image: index.docker.io/sourcegraph/postgres_exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:0d88b491e837616f563fd3097cd4113338728e857ffee6d57b4c48ba1350af9f
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/postgres_exporter:5.6.185@sha256:fa6174e74234748621248b07779e151eeae0be40843a29859d1420528743c178
           terminationMessagePolicy: FallbackToLogsOnError
           name: pgsql-exporter
           ports:

--- a/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
         - name: correct-data-dir-permissions
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/alpine-3.14:5.6.185@sha256:0baf6996d23f8087bfc2b8cf3d0aa53ccc611493b260fca43d3efd886b08a6b7
+          image: index.docker.io/sourcegraph/alpine-3.14:5.6.185@sha256:7b2ecc8f4ed6a0dd1175ad81a3b3f32ebe4b9ab2cea4cbc25aabad5d0da76ab4
           command: ["sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"]
           volumeMounts:
             - mountPath: /data
@@ -45,7 +45,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/codeintel-db:5.6.185@sha256:749d4150e02ec349ff9635f9eb3acad0240d68b609c04d79720fea46f84c3e8a
+          image: index.docker.io/sourcegraph/codeintel-db:5.6.185@sha256:07ba8ce3524bea1e9252c69917ea69865a028dd54d458728f88ae1f858a7eae9
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:
@@ -87,7 +87,7 @@ spec:
               value: postgres://sg:@localhost:5432/?sslmode=disable
             - name: PG_EXPORTER_EXTEND_QUERY_PATH
               value: /config/code_intel_queries.yaml
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/postgres_exporter:5.6.185@sha256:fa6174e74234748621248b07779e151eeae0be40843a29859d1420528743c178
+          image: index.docker.io/sourcegraph/postgres_exporter:5.6.185@sha256:5654133c53f06d5167ed92dcc978c86dd94b1cab4d818b235318958930cbaae3
           terminationMessagePolicy: FallbackToLogsOnError
           name: pgsql-exporter
           ports:

--- a/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
         - name: correct-data-dir-permissions
-          image: index.docker.io/sourcegraph/alpine-3.14:216430_2023-05-02_5.0-3cc9006de32c@sha256:923c803fb975e905424b347e19839ae0077c0dec6eea0cb71c62acd910e8e9c8
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/alpine-3.14:5.6.185@sha256:0baf6996d23f8087bfc2b8cf3d0aa53ccc611493b260fca43d3efd886b08a6b7
           command: ["sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"]
           volumeMounts:
             - mountPath: /data
@@ -45,7 +45,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: index.docker.io/sourcegraph/codeintel-db:216430_2023-05-02_5.0-3cc9006de32c@sha256:931a3b043d79f4cc7692a96810e18f0db231f36534a6748ea862903768ceeef0
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/codeintel-db:5.6.185@sha256:749d4150e02ec349ff9635f9eb3acad0240d68b609c04d79720fea46f84c3e8a
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:
@@ -87,7 +87,7 @@ spec:
               value: postgres://sg:@localhost:5432/?sslmode=disable
             - name: PG_EXPORTER_EXTEND_QUERY_PATH
               value: /config/code_intel_queries.yaml
-          image: index.docker.io/sourcegraph/postgres_exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:0d88b491e837616f563fd3097cd4113338728e857ffee6d57b4c48ba1350af9f
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/postgres_exporter:5.6.185@sha256:fa6174e74234748621248b07779e151eeae0be40843a29859d1420528743c178
           terminationMessagePolicy: FallbackToLogsOnError
           name: pgsql-exporter
           ports:

--- a/base/sourcegraph/embeddings/embeddings.Deployment.yaml
+++ b/base/sourcegraph/embeddings/embeddings.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: embeddings
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/embeddings:5.6.185@sha256:65087e05301859638667809fced25aec0aef925778566ee87facd7dbd32a4c27
+          image: index.docker.io/sourcegraph/embeddings:5.6.185@sha256:39b1607ba71da47cfe85f55026b7435654de324477bed5da112b39ab2ac1314b
           env:
             - name: POD_NAME
               valueFrom:

--- a/base/sourcegraph/embeddings/embeddings.Deployment.yaml
+++ b/base/sourcegraph/embeddings/embeddings.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: embeddings
-          image: index.docker.io/sourcegraph/embeddings:216430_2023-05-02_5.0-3cc9006de32c@sha256:c8cd7c5abca562d6a79bb524c49b9d0e76a3cb119226baa29ca0508faf652f03
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/embeddings:5.6.185@sha256:65087e05301859638667809fced25aec0aef925778566ee87facd7dbd32a4c27
           env:
             - name: POD_NAME
               valueFrom:

--- a/base/sourcegraph/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/sourcegraph/frontend/sourcegraph-frontend.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       initContainers:
         - name: migrator
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/migrator:5.6.185@sha256:04afb785655f2c209f2afde9994e86a19cd74d09f3fc9bd44db36b0be3bc3907
+          image: index.docker.io/sourcegraph/migrator:5.6.185@sha256:c723f514cf1eb217fb8c8ca54d174a4cdf2a1f912d949fe77dc88cbe15673307
           args: ["up"]
           resources:
             limits:
@@ -48,7 +48,7 @@ spec:
                 name: sourcegraph-frontend-env
       containers:
         - name: frontend
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/frontend:5.6.185@sha256:d5801aaaf69a59ecdbab30347889d8484b8ae3eeba6d7bc8ffd7b599b557edd9
+          image: index.docker.io/sourcegraph/frontend:5.6.185@sha256:99d33f1a7fbbc96dca9c68ed299968603f926b690a326308e8ee62fae534e24b
           args:
             - serve
           envFrom:

--- a/base/sourcegraph/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/sourcegraph/frontend/sourcegraph-frontend.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       initContainers:
         - name: migrator
-          image: index.docker.io/sourcegraph/migrator:216430_2023-05-02_5.0-3cc9006de32c@sha256:b8e48a03a546e955eec228843b76f44ca86211c914fc0685f81985a2c20e269b
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/migrator:5.6.185@sha256:04afb785655f2c209f2afde9994e86a19cd74d09f3fc9bd44db36b0be3bc3907
           args: ["up"]
           resources:
             limits:
@@ -48,7 +48,7 @@ spec:
                 name: sourcegraph-frontend-env
       containers:
         - name: frontend
-          image: index.docker.io/sourcegraph/frontend:216430_2023-05-02_5.0-3cc9006de32c@sha256:871772686b707f1e2d18524dc5d23837922eee244c91190ad8a636d88d3563df
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/frontend:5.6.185@sha256:d5801aaaf69a59ecdbab30347889d8484b8ae3eeba6d7bc8ffd7b599b557edd9
           args:
             - serve
           envFrom:

--- a/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
+++ b/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
@@ -35,7 +35,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: index.docker.io/sourcegraph/gitserver:216430_2023-05-02_5.0-3cc9006de32c@sha256:c8f62c859b789be15ecc78c16e9fbf21cb818262b3880d87e48b05ff8bf2c684
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/gitserver:5.6.185@sha256:47ff9355afad55e69bbcc89251a815c826e780304e84b54547740dccb5cc2338
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             initialDelaySeconds: 5

--- a/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
+++ b/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
@@ -35,7 +35,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/gitserver:5.6.185@sha256:47ff9355afad55e69bbcc89251a815c826e780304e84b54547740dccb5cc2338
+          image: index.docker.io/sourcegraph/gitserver:5.6.185@sha256:5a40cfc811de5c601bc7ef843619b685aec73ab7739e04210720c6c618506f26
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             initialDelaySeconds: 5

--- a/base/sourcegraph/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/sourcegraph/indexed-search/indexed-search.StatefulSet.yaml
@@ -33,7 +33,7 @@ spec:
               value: http://$(OTEL_AGENT_HOST):4317
             - name: OPENTELEMETRY_DISABLED
               value: "false"
-          image: index.docker.io/sourcegraph/indexed-searcher:216430_2023-05-02_5.0-3cc9006de32c@sha256:818a6d607f8ff35631a98d56ef8feb2a4257b6398473128132d85901c60b8b9d
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/indexed-searcher:5.6.185@sha256:cafa567333e83d09d14b72d0c1d11308270bc3c741ce0cf95c6983cdb633b3ef
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 6070
@@ -72,7 +72,7 @@ spec:
               value: http://$(OTEL_AGENT_HOST):4317
             - name: OPENTELEMETRY_DISABLED
               value: "false"
-          image: index.docker.io/sourcegraph/search-indexer:216430_2023-05-02_5.0-3cc9006de32c@sha256:42e4dbd82a7038c8cc46f2748e897bdf8d8d0dea9d365151dec7946fabfef687
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/search-indexer:5.6.185@sha256:633988da2276af35228f110aea5026500efeadf1f4629f71eb910cf6922f6ff5
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 6072

--- a/base/sourcegraph/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/sourcegraph/indexed-search/indexed-search.StatefulSet.yaml
@@ -33,7 +33,7 @@ spec:
               value: http://$(OTEL_AGENT_HOST):4317
             - name: OPENTELEMETRY_DISABLED
               value: "false"
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/indexed-searcher:5.6.185@sha256:cafa567333e83d09d14b72d0c1d11308270bc3c741ce0cf95c6983cdb633b3ef
+          image: index.docker.io/sourcegraph/indexed-searcher:5.6.185@sha256:d12773366ff8194828005dae8975f2535cca0f173f033be37f79fddb4a5c4ddb
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 6070
@@ -72,7 +72,7 @@ spec:
               value: http://$(OTEL_AGENT_HOST):4317
             - name: OPENTELEMETRY_DISABLED
               value: "false"
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/search-indexer:5.6.185@sha256:633988da2276af35228f110aea5026500efeadf1f4629f71eb910cf6922f6ff5
+          image: index.docker.io/sourcegraph/search-indexer:5.6.185@sha256:d9882354fa07f5168ae981cd80776c9b13048502bc63a3ea217a7abdff49149a
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 6072

--- a/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
+++ b/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
         - name: correct-data-dir-permissions
-          image: index.docker.io/sourcegraph/alpine-3.14:216430_2023-05-02_5.0-3cc9006de32c@sha256:923c803fb975e905424b347e19839ae0077c0dec6eea0cb71c62acd910e8e9c8
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/alpine-3.14:5.6.185@sha256:0baf6996d23f8087bfc2b8cf3d0aa53ccc611493b260fca43d3efd886b08a6b7
           command: ["sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"]
           volumeMounts:
             - mountPath: /data
@@ -46,7 +46,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: index.docker.io/sourcegraph/postgres-12-alpine:216430_2023-05-02_5.0-3cc9006de32c@sha256:931a3b043d79f4cc7692a96810e18f0db231f36534a6748ea862903768ceeef0
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/postgres-12-alpine:5.6.185@sha256:749d4150e02ec349ff9635f9eb3acad0240d68b609c04d79720fea46f84c3e8a
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:
@@ -90,7 +90,7 @@ spec:
               value: postgres://sg:@localhost:5432/?sslmode=disable
             - name: PG_EXPORTER_EXTEND_QUERY_PATH
               value: /config/queries.yaml
-          image: index.docker.io/sourcegraph/postgres_exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:0d88b491e837616f563fd3097cd4113338728e857ffee6d57b4c48ba1350af9f
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/postgres_exporter:5.6.185@sha256:fa6174e74234748621248b07779e151eeae0be40843a29859d1420528743c178
           terminationMessagePolicy: FallbackToLogsOnError
           name: pgsql-exporter
           ports:

--- a/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
+++ b/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
         - name: correct-data-dir-permissions
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/alpine-3.14:5.6.185@sha256:0baf6996d23f8087bfc2b8cf3d0aa53ccc611493b260fca43d3efd886b08a6b7
+          image: index.docker.io/sourcegraph/alpine-3.14:5.6.185@sha256:7b2ecc8f4ed6a0dd1175ad81a3b3f32ebe4b9ab2cea4cbc25aabad5d0da76ab4
           command: ["sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"]
           volumeMounts:
             - mountPath: /data
@@ -46,7 +46,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/postgres-12-alpine:5.6.185@sha256:749d4150e02ec349ff9635f9eb3acad0240d68b609c04d79720fea46f84c3e8a
+          image: index.docker.io/sourcegraph/postgres-12-alpine:5.6.185@sha256:07ba8ce3524bea1e9252c69917ea69865a028dd54d458728f88ae1f858a7eae9
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:
@@ -90,7 +90,7 @@ spec:
               value: postgres://sg:@localhost:5432/?sslmode=disable
             - name: PG_EXPORTER_EXTEND_QUERY_PATH
               value: /config/queries.yaml
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/postgres_exporter:5.6.185@sha256:fa6174e74234748621248b07779e151eeae0be40843a29859d1420528743c178
+          image: index.docker.io/sourcegraph/postgres_exporter:5.6.185@sha256:5654133c53f06d5167ed92dcc978c86dd94b1cab4d818b235318958930cbaae3
           terminationMessagePolicy: FallbackToLogsOnError
           name: pgsql-exporter
           ports:

--- a/base/sourcegraph/precise-code-intel/worker.Deployment.yaml
+++ b/base/sourcegraph/precise-code-intel/worker.Deployment.yaml
@@ -46,7 +46,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: index.docker.io/sourcegraph/precise-code-intel-worker:216430_2023-05-02_5.0-3cc9006de32c@sha256:6194050008a585b34e841f51529475312c24b17cbe36851d2a4988a5d1defb69
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/precise-code-intel-worker:5.6.185@sha256:091a4ded3db49da17085c4209a948bbd844e10b105e7025f911f2c1b5510f8db
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:

--- a/base/sourcegraph/precise-code-intel/worker.Deployment.yaml
+++ b/base/sourcegraph/precise-code-intel/worker.Deployment.yaml
@@ -46,7 +46,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/precise-code-intel-worker:5.6.185@sha256:091a4ded3db49da17085c4209a948bbd844e10b105e7025f911f2c1b5510f8db
+          image: index.docker.io/sourcegraph/precise-code-intel-worker:5.6.185@sha256:3e7693b5feabffd2fde441be8772297497e28ba0c77d21ab0684272814d0fde4
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:

--- a/base/sourcegraph/redis/redis-cache.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-cache.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: redis-cache
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/redis-cache:5.6.185@sha256:2da0f4883ed89b617a8193dd376e987cf0a69c64f03c881a862efa9cb059cfdd
+          image: index.docker.io/sourcegraph/redis-cache:5.6.185@sha256:c76bc920573b771e4d974ffb393272f5e1684437d07f7fb966411f20f5e07be6
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             initialDelaySeconds: 30
@@ -70,7 +70,7 @@ spec:
             - mountPath: /redis-data
               name: redis-data
         - name: redis-exporter
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/redis_exporter:5.6.185@sha256:6d121ae34e0c40a8ef53ce4a4fbe361b04e2e3a31de1ab7604ee528296f3abb8
+          image: index.docker.io/sourcegraph/redis_exporter:5.6.185@sha256:4c585d464f734a0b833215a5b9a531e8753cd77b6a2f94bb6ea61f782e5dae03
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 9121

--- a/base/sourcegraph/redis/redis-cache.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-cache.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: redis-cache
-          image: index.docker.io/sourcegraph/redis-cache:216430_2023-05-02_5.0-3cc9006de32c@sha256:60d9265507efe5b9ae51087bc7433932dfcd84d7e75c2513800baeb93fa9ea0f
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/redis-cache:5.6.185@sha256:2da0f4883ed89b617a8193dd376e987cf0a69c64f03c881a862efa9cb059cfdd
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             initialDelaySeconds: 30
@@ -70,7 +70,7 @@ spec:
             - mountPath: /redis-data
               name: redis-data
         - name: redis-exporter
-          image: index.docker.io/sourcegraph/redis_exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:edb0c9b19cacd90acc78f13f0908a7e6efd1df704e401805c24bffd241285f70
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/redis_exporter:5.6.185@sha256:6d121ae34e0c40a8ef53ce4a4fbe361b04e2e3a31de1ab7604ee528296f3abb8
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 9121

--- a/base/sourcegraph/redis/redis-store.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: redis-store
-          image: index.docker.io/sourcegraph/redis-store:216430_2023-05-02_5.0-3cc9006de32c@sha256:fd1640997cad4ce114b98a7885636e6f48483712cea754411cf4d47e770d9219
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/redis-store:5.6.185@sha256:bd4817a5c05775afad9243dac2d6715d00746bb7d03d630290048bb56426d887
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             initialDelaySeconds: 30
@@ -69,7 +69,7 @@ spec:
             - mountPath: /redis-data
               name: redis-data
         - name: redis-exporter
-          image: index.docker.io/sourcegraph/redis_exporter:216430_2023-05-02_5.0-3cc9006de32c@sha256:edb0c9b19cacd90acc78f13f0908a7e6efd1df704e401805c24bffd241285f70
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/redis_exporter:5.6.185@sha256:6d121ae34e0c40a8ef53ce4a4fbe361b04e2e3a31de1ab7604ee528296f3abb8
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 9121

--- a/base/sourcegraph/redis/redis-store.Deployment.yaml
+++ b/base/sourcegraph/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: redis-store
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/redis-store:5.6.185@sha256:bd4817a5c05775afad9243dac2d6715d00746bb7d03d630290048bb56426d887
+          image: index.docker.io/sourcegraph/redis-store:5.6.185@sha256:9a0af32842813a3b2f3ee23ce04bcdad9b02a7b56d075f4fa795b10a50ad25a1
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             initialDelaySeconds: 30
@@ -69,7 +69,7 @@ spec:
             - mountPath: /redis-data
               name: redis-data
         - name: redis-exporter
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/redis_exporter:5.6.185@sha256:6d121ae34e0c40a8ef53ce4a4fbe361b04e2e3a31de1ab7604ee528296f3abb8
+          image: index.docker.io/sourcegraph/redis_exporter:5.6.185@sha256:4c585d464f734a0b833215a5b9a531e8753cd77b6a2f94bb6ea61f782e5dae03
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 9121

--- a/base/sourcegraph/repo-updater/repo-updater.Deployment.yaml
+++ b/base/sourcegraph/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: repo-updater
-          image: index.docker.io/sourcegraph/repo-updater:216430_2023-05-02_5.0-3cc9006de32c@sha256:c91ae5f636b8a7a1b06d6c899da6a2b40f0be91aaf704116dac1c3a491db6517
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/repo-updater:5.6.185@sha256:2d2a6d69cd1a339e6a9c2ac7458ad46551aa2cdb38feb6d5250d26aaaf593589
           env:
             # OTEL_AGENT_HOST must be defined before OTEL_EXPORTER_OTLP_ENDPOINT to substitute the node IP on which the DaemonSet pod instance runs in the latter variable
             - name: OTEL_AGENT_HOST

--- a/base/sourcegraph/repo-updater/repo-updater.Deployment.yaml
+++ b/base/sourcegraph/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: repo-updater
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/repo-updater:5.6.185@sha256:2d2a6d69cd1a339e6a9c2ac7458ad46551aa2cdb38feb6d5250d26aaaf593589
+          image: index.docker.io/sourcegraph/repo-updater:5.6.185@sha256:86e7fbdffd9642e9f7be8dcb6fc5faa6bc9248689d2ae922eeba4c3800acb511
           env:
             # OTEL_AGENT_HOST must be defined before OTEL_EXPORTER_OTLP_ENDPOINT to substitute the node IP on which the DaemonSet pod instance runs in the latter variable
             - name: OTEL_AGENT_HOST

--- a/base/sourcegraph/searcher/searcher.StatefulSet.yaml
+++ b/base/sourcegraph/searcher/searcher.StatefulSet.yaml
@@ -46,7 +46,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/searcher:5.6.185@sha256:1eb1d94155eddc9a5d1db20b060a276b7a4b81c83d3c7f0eae3d3b470df896af
+          image: index.docker.io/sourcegraph/searcher:5.6.185@sha256:15a3bee6ab6295fccef5c5b06703719d49f0abe1c2dea23b069e98313aa80b08
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 3181

--- a/base/sourcegraph/searcher/searcher.StatefulSet.yaml
+++ b/base/sourcegraph/searcher/searcher.StatefulSet.yaml
@@ -46,7 +46,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: index.docker.io/sourcegraph/searcher:216430_2023-05-02_5.0-3cc9006de32c@sha256:4a40c10251454e5fda00f4b367f4f378e19b532bc93ba8a7dbfdefed27e10f05
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/searcher:5.6.185@sha256:1eb1d94155eddc9a5d1db20b060a276b7a4b81c83d3c7f0eae3d3b470df896af
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 3181

--- a/base/sourcegraph/symbols/symbols.StatefulSet.yaml
+++ b/base/sourcegraph/symbols/symbols.StatefulSet.yaml
@@ -43,7 +43,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: index.docker.io/sourcegraph/symbols:216430_2023-05-02_5.0-3cc9006de32c@sha256:bcf074d381291574d9e34df9c31665981bd4dc3ca737412bbeedf8fedcc6372b
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/symbols:5.6.185@sha256:f4756c02d5436cbbed85e295506e1f28b0d126f8fc8886565513e959b49ac924
           livenessProbe:
             httpGet:
               path: /healthz

--- a/base/sourcegraph/symbols/symbols.StatefulSet.yaml
+++ b/base/sourcegraph/symbols/symbols.StatefulSet.yaml
@@ -43,7 +43,7 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://$(OTEL_AGENT_HOST):4317
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/symbols:5.6.185@sha256:f4756c02d5436cbbed85e295506e1f28b0d126f8fc8886565513e959b49ac924
+          image: index.docker.io/sourcegraph/symbols:5.6.185@sha256:fd878be81d9d61285458e318858d33a8ac738cafe6388f1dc21b21ff173c7823
           livenessProbe:
             httpGet:
               path: /healthz

--- a/base/sourcegraph/syntect-server/syntect-server.Deployment.yaml
+++ b/base/sourcegraph/syntect-server/syntect-server.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsGroup: 101
             runAsUser: 100
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/syntax-highlighter:5.6.185@sha256:fd736b2d9413c7d45b418569e3b7b83dc443b6bbe0a38b268119f9df2afb38ed
+          image: index.docker.io/sourcegraph/syntax-highlighter:5.6.185@sha256:b9f59850b43b407bd4e67c7d38c51cded85efd9d284acea90654499d98eebb0c
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:

--- a/base/sourcegraph/syntect-server/syntect-server.Deployment.yaml
+++ b/base/sourcegraph/syntect-server/syntect-server.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsGroup: 101
             runAsUser: 100
-          image: index.docker.io/sourcegraph/syntax-highlighter:216430_2023-05-02_5.0-3cc9006de32c@sha256:d39a9234cf5f9128d5bf7430448efd4284c505fab6a310c1ec08a62a9d396fea
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/syntax-highlighter:5.6.185@sha256:fd736b2d9413c7d45b418569e3b7b83dc443b6bbe0a38b268119f9df2afb38ed
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:

--- a/base/sourcegraph/worker/worker.Deployment.yaml
+++ b/base/sourcegraph/worker/worker.Deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - configMapRef:
                 name: embeddings-backend
                 optional: true
-          image: index.docker.io/sourcegraph/worker:216430_2023-05-02_5.0-3cc9006de32c@sha256:d3d9e1d684a1a4a337810dc0a9caa95bd9caa17120527be227ca3b5cae622b59
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/worker:5.6.185@sha256:8c95461e4f4aa54b442b9d163a91c8571a066f3afda76d844a1a510c4ab2247a
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:

--- a/base/sourcegraph/worker/worker.Deployment.yaml
+++ b/base/sourcegraph/worker/worker.Deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - configMapRef:
                 name: embeddings-backend
                 optional: true
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/worker:5.6.185@sha256:8c95461e4f4aa54b442b9d163a91c8571a066f3afda76d844a1a510c4ab2247a
+          image: index.docker.io/sourcegraph/worker:5.6.185@sha256:8d8666abf5ff5f0cfb4e6724d657c271c9a7b13ee6386fabbab7bc67d5567191
           terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:

--- a/components/executors/dind/executor.Deployment.yaml
+++ b/components/executors/dind/executor.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: executor
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/executor:5.6.185@sha256:214a878e46713935a9037af31b8b513a5827487bde2bb02a48aa825b78843e06
+          image: index.docker.io/sourcegraph/executor:5.6.185@sha256:bb44086165383ddd691275ec679766bc58e85bc5be47462493b40596f9136e69
           imagePullPolicy: Always
           livenessProbe:
             exec:
@@ -60,7 +60,7 @@ spec:
             - mountPath: /scratch
               name: executor-scratch
         - name: dind
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/dind:5.6.185@sha256:09e6303731333cc42b54c8b867c5186d455b6589aa8e45204b74ca9825bc4c7b
+          image: index.docker.io/sourcegraph/dind:5.6.185@sha256:328402b8bdf867bf1d082a84c9c16e83d448c43d936fb98187450145e4d8e236
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/components/executors/dind/executor.Deployment.yaml
+++ b/components/executors/dind/executor.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: executor
-          image: index.docker.io/sourcegraph/executor:insiders@sha256:80d7f19dc8325af1a690609721e614653222a964a9fb6c8d150751d05402d199
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/executor:5.6.185@sha256:214a878e46713935a9037af31b8b513a5827487bde2bb02a48aa825b78843e06
           imagePullPolicy: Always
           livenessProbe:
             exec:
@@ -60,7 +60,7 @@ spec:
             - mountPath: /scratch
               name: executor-scratch
         - name: dind
-          image: index.docker.io/sourcegraph/dind:insiders@sha256:06a4a6ac7c200cdd14ebb1cde5be3f02e5df525e1a3e4c1bc258b08e514e550c
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/dind:5.6.185@sha256:09e6303731333cc42b54c8b867c5186d455b6589aa8e45204b74ca9825bc4c7b
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/components/executors/dind/patches/docker-daemon.ConfigMap.yaml
+++ b/components/executors/dind/patches/docker-daemon.ConfigMap.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 data:
   daemon.json: |
     { "insecure-registries":["private-docker-registry:5000"] }
-
 kind: ConfigMap
 metadata:
   labels:

--- a/components/executors/k8s/executor.Deployment.yaml
+++ b/components/executors/k8s/executor.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: executor
       containers:
         - name: executor
-          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/executor-kubernetes:5.6.185@sha256:1f1a9f6bca19f19682dd99f073a685b7de51c3d00effdddac5beb9381a75b4f9
+          image: index.docker.io/sourcegraph/executor-kubernetes:5.6.185@sha256:1814b04535f73cffea20a768f72441faee57cb1ec3287e9328a21a149ace8763
           imagePullPolicy: Always
           livenessProbe:
             exec:

--- a/components/executors/k8s/executor.Deployment.yaml
+++ b/components/executors/k8s/executor.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: executor
       containers:
         - name: executor
-          image: index.docker.io/sourcegraph/executor-kubernetes:5.1_231128_2023-06-27_5.0-7ac9ba347103@sha256:0d55f068254a50ab98ac142a5a40df3ddedefebdebc66b019eba32cc04c9ea43
+          image: us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/executor-kubernetes:5.6.185@sha256:1f1a9f6bca19f19682dd99f073a685b7de51c3d00effdddac5beb9381a75b4f9
           imagePullPolicy: Always
           livenessProbe:
             exec:


### PR DESCRIPTION
## Description

Update images with latest release

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

Tested locally

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
