### PR TITLE
Updated RBAC for KUBERNETES_SINGLE_JOB_POD mode

### DIFF
--- a/components/executors/k8s/rbac/executor.Role.yaml
+++ b/components/executors/k8s/rbac/executor.Role.yaml
@@ -26,3 +26,10 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete


### PR DESCRIPTION
## Description

`KUBERNETES_SINGLE_JOB_POD` mode was enabled by default in v5.6 with [PR 64088](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64088) which includes a new requirement to manage ephemeral k8s Secrets.

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

N/A