### PR TITLE
Adding pgsql datasource for Grafana

### DIFF
--- a/base/monitoring/grafana/grafana.ConfigMap.yaml
+++ b/base/monitoring/grafana/grafana.ConfigMap.yaml
@@ -17,3 +17,12 @@ data:
         url: http://prometheus:30090
         isDefault: true
         editable: false
+      - name: pgsql
+        type: postgres
+        url: $PGHOST:$PGPORT
+        user: $PGGRAFANAUSER
+        database: $PGDATABASE
+        secureJsonData:
+          password: $PGGRAFANAPASSWORD
+        jsonData:
+          sslmode: $PGSSLMODE


### PR DESCRIPTION
## Description

For [PS-83: Create pgsql datasource in Grafana](https://linear.app/sourcegraph/issue/PS-83/create-pgsql-datasource-in-grafana)

<!-- description here -->

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [x] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [x] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Tested on test instance for upgrades and new installs, with and without the env vars configured

### Alternatives Considered
I tried to change the existing ConfigMap just mounted as a single file inside the directory, so then I could just add Postgres via a separate ConfigMap via subDir mount, but that threw Grafana for a loop because the datasources.yml file is not declarative (ex. Terraform), but just an input ingestion method to Grafana's config state (maintained in a MongoDB inside the Grafana container?), and when the datasources.yml file gets a new inode on an existing instance, Grafana fails to start up, because we have default:true on Prometheus, so Grafana seeing the same Prometheus data source in a new file at a new inode, so it errors out like we're trying to declare a second Prometheus datasource as also default, without first deleting the first one... we'd have to also migrate the Grafana config on existing instances by declaring a delete datasources block to delete the existing default Prometheus before creating a "new" one, and if we're going through all that, I'd say we should also set prune:true to cover us for the next time someone needs to change something, but that feature's not available in v7.5 :facepalm: