### PR TITLE
Enable auto namespace creation for the executors example

### DIFF
--- a/examples/executors/kustomization.yaml
+++ b/examples/executors/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 components:
   # Native Kubernetes Executors
   - ../../components/executors/k8s
+  - ../../components/resources/namespace
 patches:
   - path: patches/executor.ConfigMap.yaml
 secretGenerator:


### PR DESCRIPTION
## Description

when deploying the executors example to `minikube` locally, I would get the following error when attempting to deploy:

```
Error from server (NotFound): error when creating "cluster.yaml": namespaces "executor-sourcegraph" not found
```

The deployment steps I took are:

0. Set the default namespace 'cause it's tiresome typing it all of the time:
```
kubectl config set-context --current --namespace=executor-sourcegraph   
```
1. Generate the deployment file:
```
kubectl kustomize examples/executors -o cluster.yaml
```
2. Deploy
``` 
kubectl apply -f cluster.yaml
```
3. Get the error message

I am not very experienced with K8s, so I asked Cody for advice, and was told to add the namespace resource to `components`, so I tried that, and it worked!

I could also set the namespace ahead of time using `kubectl create namespace executor-sourcegraph`, but it seems cleaner to include it in the Kustomize config.

I don't know if this change needs to be applied anywhere else (or even if it's legitimate to apply here)

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

Other than the steps described above, gotta come up with one.
