### PR TITLE
fix: use new 16 postgres containers

### DIFF
--- a/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -45,7 +45,7 @@ spec:
             runAsUser: 70
       containers:
         - name: codeinsights
-          image: index.docker.io/sourcegraph/codeinsights-db:5.9.1590@sha256:4e75b2c463ce1ef3bfeec4bb71a16693df02005e66b9e697859ce61064e08f42
+          image: index.docker.io/sourcegraph/postgresql-16-codeinsights:insiders@sha256:4e75b2c463ce1ef3bfeec4bb71a16693df02005e66b9e697859ce61064e08f42
           env:
             - name: POSTGRES_DB
               value: postgres

--- a/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
@@ -45,7 +45,7 @@ spec:
             runAsUser: 70
       containers:
         - name: codeinsights
-          image: index.docker.io/sourcegraph/postgresql-16-codeinsights:insiders@sha256:4e75b2c463ce1ef3bfeec4bb71a16693df02005e66b9e697859ce61064e08f42
+          image: index.docker.io/sourcegraph/postgresql-16-codeinsights:insiders
           env:
             - name: POSTGRES_DB
               value: postgres

--- a/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -45,7 +45,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: index.docker.io/sourcegraph/postgres-16:insiders@sha256:3d5dd36e3af6b643903f507422be19ed1cb1f5f71c4541572d4a8a252e81aeb8
+          image: index.docker.io/sourcegraph/postgres-16:insiders
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:

--- a/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -45,7 +45,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: index.docker.io/sourcegraph/postgres-16:insiders
+          image: index.docker.io/sourcegraph/postgresql-16:insiders
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:

--- a/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
+++ b/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml
@@ -45,7 +45,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: index.docker.io/sourcegraph/codeintel-db:5.9.1590@sha256:3d5dd36e3af6b643903f507422be19ed1cb1f5f71c4541572d4a8a252e81aeb8
+          image: index.docker.io/sourcegraph/postgres-16:insiders@sha256:3d5dd36e3af6b643903f507422be19ed1cb1f5f71c4541572d4a8a252e81aeb8
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:

--- a/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
+++ b/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
@@ -46,7 +46,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: index.docker.io/sourcegraph/postgres-16:insiders@sha256:3d5dd36e3af6b643903f507422be19ed1cb1f5f71c4541572d4a8a252e81aeb8
+          image: index.docker.io/sourcegraph/postgres-16:insiders
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:

--- a/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
+++ b/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
@@ -46,7 +46,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: index.docker.io/sourcegraph/postgres-12-alpine:5.9.1590@sha256:3d5dd36e3af6b643903f507422be19ed1cb1f5f71c4541572d4a8a252e81aeb8
+          image: index.docker.io/sourcegraph/postgres-16:insiders@sha256:3d5dd36e3af6b643903f507422be19ed1cb1f5f71c4541572d4a8a252e81aeb8
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:

--- a/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
+++ b/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml
@@ -46,7 +46,7 @@ spec:
               memory: "50Mi"
       containers:
         - name: pgsql
-          image: index.docker.io/sourcegraph/postgres-16:insiders
+          image: index.docker.io/sourcegraph/postgresql-16:insiders
           terminationMessagePolicy: FallbackToLogsOnError
           readinessProbe:
             exec:


### PR DESCRIPTION
## Description

We need to use the new postgres containers

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [x] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [x] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan
CI
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
