### PR TITLE
feat(rel): add step to release to update main with latest version

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -333,6 +333,23 @@ promoteToPublic:
           Promoted release is **publicly available** through a git tag at [\`{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/{{version}}).
           EOF
 
+      - name: 'Promote on release registry'
+        cmd: |
+          echo "Promoting deploy-sourcegraph-k8s {{version}} release on release registry"
+          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/k8s/{{version}}/promote")
+          exit_code=$?
+
+          if [ $exit_code != 0 ]; then
+            echo "❌ Failed to promote release on release registry, got:"
+            echo "--- raw body ---"
+            echo $body
+            echo "--- raw body ---"
+            exit $exit_code
+          else
+            echo "Build created, see:"
+            echo $body | jq .web_url
+          fi
+
       - name: "update main with latest version"
         cmd: |
           set -eu
@@ -390,19 +407,3 @@ promoteToPublic:
             --body "Test plan: automated release PR, CI will perform additional checks"
           echo "🚢 Please check the associated CI build to ensure the process completed".
 
-      - name: 'Promote on release registry'
-        cmd: |
-          echo "Promoting deploy-sourcegraph-k8s {{version}} release on release registry"
-          body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/k8s/{{version}}/promote")
-          exit_code=$?
-
-          if [ $exit_code != 0 ]; then
-            echo "❌ Failed to promote release on release registry, got:"
-            echo "--- raw body ---"
-            echo $body
-            echo "--- raw body ---"
-            exit $exit_code
-          else
-            echo "Build created, see:"
-            echo $body | jq .web_url
-          fi

--- a/release.yaml
+++ b/release.yaml
@@ -332,6 +332,64 @@ promoteToPublic:
           cat << EOF | buildkite-agent annotate --style info
           Promoted release is **publicly available** through a git tag at [\`{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/{{version}}).
           EOF
+
+      - name: "update main with latest version"
+        cmd: |
+          set -eu
+          branch="promote/release-{{version}}-update-main"
+          echo "Checking out origin/main"
+          git fetch origin main
+          git switch main
+          echo "Creating branch origin/${branch}"
+          git switch -c "${branch}"
+
+      - name: "sg ops"
+        cmd: |
+          set -eu
+          sg ops update-images \
+            --kind k8s \
+            --registry index.docker.io/sourcegraph \
+            --docker-username=$DOCKER_USERNAME \
+            --docker-password=$DOCKER_PASSWORD \
+            --pin-tag {{inputs.server.tag}} \
+            base/
+
+      - name: "sg ops (executors)"
+        cmd: |
+          set -eu
+          sg ops update-images \
+            --kind k8s \
+            --registry index.docker.io/sourcegraph \
+            --docker-username=$DOCKER_USERNAME \
+            --docker-password=$DOCKER_PASSWORD \
+            --pin-tag {{inputs.server.tag}} \
+            components/executors/
+
+      - name: "git:commit"
+        cmd: |
+          set -eu
+          branch="promote/release-{{version}}-update-main"
+          find . -name "*.yaml" | xargs git add
+          find . -name "*.yml" | xargs git add
+
+          # Careful with the quoting for the config, using double quotes will lead
+          # to the shell dropping out all quotes from the json, leading to failed
+          # parsing.
+          git commit -am 'update-main: {{version}}' -m 'update main with latest release'
+          git push origin "${branch}"
+          
+      - name: "github:pr"
+        cmd: |
+          set -eu
+          internal_branch="promote/release-{{version}}-update-main"
+          gh pr create \
+            --fill \
+            --draft \
+            --base "$internal_branch" \
+            --title "Update main: build {{version}}" \
+            --body "Test plan: automated release PR, CI will perform additional checks"
+          echo "🚢 Please check the associated CI build to ensure the process completed".
+
       - name: 'Promote on release registry'
         cmd: |
           echo "Promoting deploy-sourcegraph-k8s {{version}} release on release registry"


### PR DESCRIPTION
## Description

Add step to build process that creates a PR to update `main` with the latest release version.

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [NA] Update [CHANGELOG.md](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/CHANGELOG.md)
- [NA] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [NA] Kustomiz-specific changes
- [NA] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [NA] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [NA] Verify all images have a valid tag and SHA256 sum

## Test plan

CI during release cycle.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
