### PR TITLE
Fix multi-version replica bug

### DIFF
--- a/components/utils/multi-version-upgrade/kustomization.yaml
+++ b/components/utils/multi-version-upgrade/kustomization.yaml
@@ -7,7 +7,7 @@ patches:
         value: 0
     target:
       group: apps
-      kind: .*
+      kind: Deployment|StatefulSet
       name: .*
       version: v1
   - patch: |-


### PR DESCRIPTION
## Description

This PR closes https://linear.app/sourcegraph/issue/REL-688/multi-version-upgrade-util-component-bug

In which the multiversion utility kustomize patch attempts to apply replica settings to resources that don't have replicas
```
The request is invalid: patch: Invalid value: "map[metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"apps/v1\",\"kind\":\"DaemonSet\",\"metadata\":{\"annotations\":{\"description\":\"DaemonSet to ensure all nodes run a node-exporter pod.\",\"seccomp.security.alpha.kubernetes.io/pod\":\"docker/default\"},\"labels\":{\"app\":\"node-exporter\",\"app.kubernetes.io/component\":\"node-exporter\",\"deploy\":\"sourcegraph\"},\"name\":\"node-exporter\",\"namespace\":\"default\"},\"spec\":{\"replicas\":0,\"selector\":{\"matchLabels\":{\"app\":\"node-exporter\"}},\"template\":{\"metadata\":{\"annotations\":{\"description\":\"Collects and exports machine metrics.\",\"kubectl.kubernetes.io/default-container\":\"node-exporter\"},\"labels\":{\"app\":\"node-exporter\",\"deploy\":\"sourcegraph\"}},\"spec\":{\"affinity\":null,\"automountServiceAccountToken\":false,\"containers\":[{\"args\":[\"--web.listen-address=:9100\",\"--path.sysfs=/host/sys\",\"--path.rootfs=/host/root\",\"--path.procfs=/host/proc\",\"--no-collector.wifi\",\"--no-collector.hwmon\",\"--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)\",\"--collector.netclass.ignored-devices=^(veth.*)$\",\"--collector.netdev.device-exclude=^(veth.*)$\"],\"env\":null,\"image\":\"index.docker.io/sourcegraph/node-exporter:5.11.0@sha256:e63d7353829d62fde4fb27084fdb2a0e49d5873e591e97430e3a2e83414e7edc\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"failureThreshold\":3,\"httpGet\":{\"port\":\"metrics\",\"scheme\":\"HTTP\"},\"initialDelaySeconds\":0,\"periodSeconds\":10,\"successThreshold\":1,\"timeoutSeconds\":1},\"name\":\"node-exporter\",\"ports\":[{\"containerPort\":9100,\"name\":\"metrics\",\"protocol\":\"TCP\"}],\"readinessProbe\":{\"failureThreshold\":3,\"httpGet\":{\"port\":\"metrics\",\"scheme\":\"HTTP\"},\"initialDelaySeconds\":0,\"periodSeconds\":10,\"successThreshold\":1,\"timeoutSeconds\":1},\"resources\":{\"limits\":{\"cpu\":\"1\",\"memory\":\"1Gi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"250M\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"readOnlyRootFilesystem\":true,\"runAsGroup\":65534,\"runAsUser\":65534},\"terminationMessagePolicy\":\"FallbackToLogsOnError\",\"volumeMounts\":[{\"mountPath\":\"/host/root\",\"mountPropagation\":\"HostToContainer\",\"name\":\"rootfs\",\"readOnly\":true},{\"mountPath\":\"/host/sys\",\"mountPropagation\":\"HostToContainer\",\"name\":\"sys\",\"readOnly\":true},{\"mountPath\":\"/host/proc\",\"mountPropagation\":\"HostToContainer\",\"name\":\"proc\",\"readOnly\":true}]}],\"hostPID\":true,\"nodeSelector\":null,\"securityContext\":{\"fsGroup\":65534,\"fsGroupChangePolicy\":\"OnRootMismatch\",\"runAsGroup\":65534,\"runAsNonRoot\":true,\"runAsUser\":65534},\"terminationGracePeriodSeconds\":30,\"tolerations\":null,\"volumes\":[{\"hostPath\":{\"path\":\"/\"},\"name\":\"rootfs\"},{\"hostPath\":{\"path\":\"/sys\"},\"name\":\"sys\"},{\"hostPath\":{\"path\":\"/proc\"},\"name\":\"proc\"}]}}}}\n]] spec:map[replicas:0 template:map[spec:map[affinity:<nil> nodeSelector:<nil> tolerations:<nil>]]]]": strict decoding error: unknown field "spec.replicas"
```

## Test plan

Tested locally on a kind cluster, after the update only the expected pods come up and theres no error when running the kustomize patch
```
➜  deploy-sourcegraph-k8s git:(v5.9.0) ✗ k get pods
NAME                  READY   STATUS    RESTARTS   AGE
codeinsights-db-0     2/2     Running   0          3m56s
codeintel-db-0        2/2     Running   0          3m57s
node-exporter-5gk2r   1/1     Running   0          3m58s
pgsql-0               2/2     Running   0          3m56s
```
