### PR TITLE
feat(rel): add syntactic code intel worker service

### DIFF
--- a/base/sourcegraph/kustomization.yaml
+++ b/base/sourcegraph/kustomization.yaml
@@ -13,5 +13,6 @@ resources:
   - repo-updater
   - searcher
   - symbols
+  - syntactic-code-intel
   - syntect-server
   - worker

--- a/base/sourcegraph/syntactic-code-intel/kustomization.yaml
+++ b/base/sourcegraph/syntactic-code-intel/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - worker.Deployment.yaml
+  - worker.Service.yaml

--- a/base/sourcegraph/syntactic-code-intel/worker.Deployment.yaml
+++ b/base/sourcegraph/syntactic-code-intel/worker.Deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: High level syntax analysis
+  labels:
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: syntactic-code-intel
+  name: syntactic-code-intel
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: syntactic-code-intel
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        deploy: sourcegraph
+        app: syntactic-code-intel
+    spec:
+      containers:
+        - name: syntactic-code-intel
+          env:
+            - name: PRECISE_CODE_INTEL_UPLOAD_BACKEND
+              value: blobstore
+            - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT
+              value: http://blobstore:9000
+            - name: SYNTACTIC_CODE_INTEL_WORKER_ADDR
+              value: ":3188"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          image: index.docker.io/sourcegraph/syntactic-code-intel-worker:6.0.0@sha256:50bdeb38b196f0fc21404969016bf8263f78144292e905867e93480f66c8251c
+          terminationMessagePath: FallbackToLogsOnError
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: debug
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: debug
+              scheme: HTTP
+            periodSeconds: 5
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 3188
+              name: http
+            - containerPort: 6060
+              name: debug
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4G
+            requests:
+              cpu: 500m
+              memory: 2G
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsGroup: 101
+            runAsUser: 100
+      securityContext:
+        fsGroup: 101
+        runAsUser: 100
+        fsGroupChangePolicy: OnRootMismatch

--- a/base/sourcegraph/syntactic-code-intel/worker.Service.yaml
+++ b/base/sourcegraph/syntactic-code-intel/worker.Service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "6060"
+    sourcegraph.prometheus/scrape: "true"
+  labels:
+    app: syntactic-code-intel
+    app.kubernetes.io/component: syntactic-code-intel
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+  name: syntactic-code-intel
+spec:
+  ports:
+    - name: http
+      port: 3188
+      targetPort: http
+    - name: debug
+      port: 6060
+      targetPort: debug
+  selector:
+    app: syntactic-code-intel
+  type: ClusterIP


### PR DESCRIPTION
## Description

Add SCIW service to deployment.

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

Verified service is running and healthy:

```
deploy-sourcegraph-k8s 02-18-feat_rel_add_syntactic_code_intel_worker_service * um
❯ k get pods -n ns-sourcegraph
NAME                                           READY   STATUS    RESTARTS        AGE
blobstore-67ddf96c55-j5qlh                     1/1     Running   0               9m45s
codeinsights-db-0                              2/2     Running   0               9m44s
codeintel-db-0                                 2/2     Running   0               9m44s
gitserver-0                                    1/1     Running   2 (8m2s ago)    9m44s
grafana-0                                      1/1     Running   0               9m44s
indexed-search-0                               2/2     Running   0               9m44s
node-exporter-kbwgv                            1/1     Running   0               9m44s
pgsql-0                                        2/2     Running   0               9m44s
precise-code-intel-worker-69c4dd7648-2dqwk     1/1     Running   1 (8m14s ago)   9m45s
prometheus-54f89f9959-dsj44                    1/1     Running   0               9m45s
redis-cache-84cc945d5c-rzsbm                   2/2     Running   0               9m45s
redis-store-5bbf47654b-vdjjx                   2/2     Running   0               9m44s
repo-updater-bbcf9c47d-shghn                   1/1     Running   5 (8m37s ago)   9m44s
searcher-0                                     1/1     Running   0               9m44s
sourcegraph-frontend-765565bbd5-kbvxh          1/1     Running   0               9m44s
sourcegraph-frontend-765565bbd5-l2qq7          1/1     Running   0               9m44s
symbols-0                                      1/1     Running   0               9m43s
syntactic-code-intel-worker-86b4558fd8-rsg9h   1/1     Running   0               3m16s
syntactic-code-intel-worker-86b4558fd8-t8wcc   1/1     Running   0               3m16s
syntect-server-767b459548-94fxl                1/1     Running   0               9m44s
worker-d4cf796b7-mwxjq                         1/1     Running   0               9m44s

deploy-sourcegraph-k8s 02-18-feat_rel_add_syntactic_code_intel_worker_service * um
❯ k describe pod syntactic-code-intel-worker-86b4558fd8-rsg9h -n ns-sourcegraph
Name:             syntactic-code-intel-worker-86b4558fd8-rsg9h
Namespace:        ns-sourcegraph
Priority:         0
Service Account:  default
Node:             sourcegraph-control-plane/192.168.97.2
Start Time:       Tue, 18 Feb 2025 16:24:21 -0500
Labels:           app=syntactic-code-intel-worker
                  deploy=sourcegraph
                  pod-template-hash=86b4558fd8
Annotations:      <none>
Status:           Running
IP:               10.244.0.38
IPs:
  IP:           10.244.0.38
Controlled By:  ReplicaSet/syntactic-code-intel-worker-86b4558fd8
Containers:
  syntactic-code-intel-worker:
    Container ID:   containerd://4b1942a3ef2ca9725544e76a0102e2119a873711f605e93da1dc9c3cecbfe601
    Image:          index.docker.io/sourcegraph/syntactic-code-intel-worker:6.0.0@sha256:50bdeb38b196f0fc21404969016bf8263f78144292e905867e93480f66c8251c
    Image ID:       docker.io/sourcegraph/syntactic-code-intel-worker@sha256:50bdeb38b196f0fc21404969016bf8263f78144292e905867e93480f66c8251c
    Ports:          3188/TCP, 6060/TCP
    Host Ports:     0/TCP, 0/TCP
    State:          Running
      Started:      Tue, 18 Feb 2025 16:24:22 -0500
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     2
      memory:  4G
    Requests:
      cpu:      100m
      memory:   250M                                                                                                                                               Liveness:   http-get http://:debug/healthz delay=60s timeout=5s period=10s #success=1 #failure=3                                                               Readiness:  http-get http://:debug/ready delay=0s timeout=5s period=5s #success=1 #failure=3                                                                   Environment:
      SYNTACTIC_CODE_INTEL_BACKEND:              blobstore
      SYNTACTIC_CODE_INTEL_UPLOAD_AWS_ENDPOINT:  http://blobstore:9000
      SYNTACTIC_CODE_INTEL_WORKER_ADDR:          :3188
      POD_NAME:                                  syntactic-code-intel-worker-86b4558fd8-rsg9h (v1:metadata.name)
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-q8x7x (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True
  Initialized                 True
  Ready                       True
  ContainersReady             True
  PodScheduled                True
Volumes:
  kube-api-access-q8x7x:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   Burstable
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason     Age    From               Message
  ----     ------     ----   ----               -------
  Normal   Scheduled  3m28s  default-scheduler  Successfully assigned ns-sourcegraph/syntactic-code-intel-worker-86b4558fd8-rsg9h to sourcegraph-control-plane
  Normal   Pulled     3m27s  kubelet            Container image "index.docker.io/sourcegraph/syntactic-code-intel-worker:6.0.0@sha256:50bdeb38b196f0fc21404969016bf8263f78144292e905867e93480f66c8251c" already present on machine
  Normal   Created    3m27s  kubelet            Created container: syntactic-code-intel-worker
  Normal   Started    3m27s  kubelet            Started container syntactic-code-intel-worker
  Warning  Unhealthy  3m27s  kubelet            Readiness probe failed: Get "http://10.244.0.38:6060/ready": dial tcp 10.244.0.38:6060: connect: connection refused
```

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
