### PR TITLE
add gitserver startup probe

### DIFF
--- a/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
+++ b/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
@@ -37,6 +37,14 @@ spec:
               value: http://$(OTEL_AGENT_HOST):4317
           image: index.docker.io/sourcegraph/gitserver:6.0.0@sha256:aec9bf6993c243a283109104cd7c44be3c85680b77e3e8be0c5fba8f01a3bd35
           terminationMessagePolicy: FallbackToLogsOnError
+          # Temporary: when migrating from repo names to repo IDs on disk,
+          # gitserver can take a little while to start up. To avoid killing the
+          # pod because of a failed liveness probe, we give it 2 minutes to start up.
+          startupProbe:
+            tcpSocket:
+              port: rpc
+            failureThreshold: 120
+            periodSeconds: 1
           livenessProbe:
             initialDelaySeconds: 5
             tcpSocket:


### PR DESCRIPTION
## Description

This adds a startup probe to gitserver so that it's not immediately killed while it's starting up and migrating the on-disk format for repos.

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] ~Update [CHANGELOG.md](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/CHANGELOG.md)~ CHANGELOG.md no longere exists
- [ ] ~Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)~ Does not exist
- [ ] ~Kustomiz-specific changes~ Not applicable
- [x] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] ~Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)~ Not applicable
- [x] Verify all images have a valid tag and SHA256 sum

## Test plan

Passed linters, ran it locally, plan to exercise it when we deploy to s2 and dotcom.