### PR TITLE
security: add semgrep scan for scanning infra related files

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,41 @@
+name: Semgrep - SAST Scan
+
+on:
+  pull_request_target:
+    types: [edited, opened, synchronize, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep:1.104.0
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Checkout semgrep-rules repo
+        uses: actions/checkout@v4
+        with:
+          repository: sourcegraph/security-semgrep-rules
+          token: ${{ secrets.GH_SEMGREP_SAST_TOKEN }}
+          path: semgrep-rules
+
+      - name: Run Semgrep SAST Scan
+        run: |
+          mv semgrep-rules ../
+          semgrep ci -f ../semgrep-rules/semgrep-rules/ --metrics=off --oss-only --suppress-errors --sarif -o results.sarif --exclude='semgrep-rules' --baseline-commit "$(git merge-base main HEAD)" || true
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Add semgrep scan to scan infra related files and changes

## Description

<!-- description here -->

---

## Checklist

- CI 🟢 
- Semgrep scan should execute on all pull request changes

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [x] Update [CHANGELOG.md](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/CHANGELOG.md)
- [x] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [x] Kustomiz-specific changes
- [x] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [x] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [x] Verify all images have a valid tag and SHA256 sum

## Test plan

- Semgrep scan should execute on all pull request changes

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
