### PR TITLE
use beta agent for mise default test

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,27 +1,23 @@
+agents:
+  queue: beta
 steps:
   - label: ":k8s:"
     command: .buildkite/verify-yaml.sh
-    agents: { queue: standard }
 
   - label: ":k8s:"
     command: .buildkite/verify-label.sh
-    agents: { queue: standard }
 
   - label: ":k8s:"
     command: .buildkite/verify-rbac-labels.sh
-    agents: { queue: standard }
 
   - label: ":git: :sleuth_or_spy:"
     command: .buildkite/verify-release/verify-release.sh
-    agents: { queue: standard }
 
   - label: ":k8s: :sleuth_or_spy:"
     command: .buildkite/check-image-names.sh
-    agents: { queue: standard }
 
   - label: ":k8s:"
     command: .buildkite/verify-overlays.sh
-    agents: { queue: standard }
 
   # Please keep in mind that the release manifest uses specific branch names when creating releases.
   # Therefore, if you update them, or if you decide to change how we detect what kind of build we're dealing


### PR DESCRIPTION
## Description

<!-- description here -->

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
