### PR TITLE
fix: update internal registry from legacy to new revamp registry

### DIFF
--- a/batch-change/release.yaml
+++ b/batch-change/release.yaml
@@ -34,7 +34,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -44,7 +44,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -55,7 +55,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -65,7 +65,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -76,7 +76,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -86,7 +86,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \

--- a/release.yaml
+++ b/release.yaml
@@ -34,7 +34,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -44,7 +44,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -83,7 +83,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -93,7 +93,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -130,7 +130,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -140,7 +140,7 @@ internal:
             set -eu
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \


### PR DESCRIPTION
## Problem
The release creation process was failing with 404 errors when trying to fetch images like cadvisor:6.6.2517 from the legacy internal registry.

## Root Cause
Recent changes in the main sourcegraph repo migrated from legacy registries to new 'revamp' registries, but the deploy repos were still hardcoded to use the old registry.

## Solution
- Replace `us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal` with `us-docker.pkg.dev/sourcegraph-images/internal`
- Updated both release.yaml and batch-change/release.yaml
- Tested and confirmed images exist in the new registry

## Test Plan
- Validated that cadvisor:6.6.2517 exists in new registry but not in old registry
- Successfully tested sg ops update-images command with new registry
- Confirmed this fixes the original 404 errors during release creation