### PR TITLE
fix(rel): add migrator job to release process

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -49,6 +49,16 @@ internal:
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
               components/executors/
+        - name: "sg ops (migrator)"
+          cmd: |
+            set -eu
+            sg ops update-images \
+              --kind k8s \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              components/utils/migrator/
         - name: "git:branch"
           cmd: |
             set -eu
@@ -98,6 +108,16 @@ internal:
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
               components/executors/
+        - name: "sg ops (migrator)"
+          cmd: |
+            set -eu
+            sg ops update-images \
+              --kind k8s \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              components/utils/migrator/
         - name: "git:branch"
           cmd: |
             set -eu
@@ -145,6 +165,16 @@ internal:
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
               components/executors/
+        - name: "sg ops (migrator)"
+          cmd: |
+            set -eu
+            sg ops update-images \
+              --kind k8s \
+              --registry us-docker.pkg.dev/sourcegraph-images/internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              components/utils/migrator/
         - name: "git:branch"
           cmd: |
             set -eu
@@ -248,6 +278,16 @@ promoteToPublic:
             --docker-password=$DOCKER_PASSWORD \
             --pin-tag {{inputs.server.tag}} \
             components/executors/
+      - name: "sg ops (migrator)"
+        cmd: |
+          set -eu
+          sg ops update-images \
+            --kind k8s \
+            --registry index.docker.io/sourcegraph \
+            --docker-username=$DOCKER_USERNAME \
+            --docker-password=$DOCKER_PASSWORD \
+            --pin-tag {{inputs.server.tag}} \
+            components/utils/migrator/
       - name: "git:branch"
         cmd: |
           set -eu
@@ -381,6 +421,17 @@ promoteToPublic:
             --docker-password=$DOCKER_PASSWORD \
             --pin-tag {{inputs.server.tag}} \
             components/executors/
+
+      - name: "sg ops (migrator)"
+        cmd: |
+          set -eu
+          sg ops update-images \
+            --kind k8s \
+            --registry index.docker.io/sourcegraph \
+            --docker-username=$DOCKER_USERNAME \
+            --docker-password=$DOCKER_PASSWORD \
+            --pin-tag {{inputs.server.tag}} \
+            components/utils/migrator/
 
       - name: "git:commit"
         cmd: |


### PR DESCRIPTION
## Description

The migrator job was missing from the release process, causing the image tag to no be updated during releases.

This adds the steps to update the image during the release process.

## Checklist


- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [x] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

Tested actions locally:

```shell
sg release create --workdir=. --version=v6.8.2313 --inputs=server=v6.8.2313 --pretend
...
👉 [      step] Pretending to run step "sg ops (migrator)"
   [sg ops (migrator)] set -eu
   [sg ops (migrator)] sg ops update-images \
   [sg ops (migrator)]   --kind k8s \
   [sg ops (migrator)]   --registry us-docker.pkg.dev/sourcegraph-images/internal \
   [sg ops (migrator)]   --docker-username=$DOCKER_USERNAME \
   [sg ops (migrator)]   --docker-password=$DOCKER_PASSWORD \
   [sg ops (migrator)]   --pin-tag 6.8.2313 \
   [sg ops (migrator)]   components/utils/migrator/
   [sg ops (migrator)] 
...
```
