### PR TITLE
fix: don't upload SCIP index to dotcom

### DIFF
--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -17,11 +17,6 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Generate SCIP data
         run: scip-go
-      - name: Upload SCIP to Cloud
-        run: src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
-        env:
-          SRC_ENDPOINT: https://sourcegraph.com/
-          SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
       - name: Upload SCIP to S2
         run: src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:


### PR DESCRIPTION
## Description

The repo is not listed in https://sourcegraph.com/search.

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan
N/A