### PR TITLE
chore/platform: update k8s to support jaeger 2.16 config

### DIFF
--- a/base/monitoring/jaeger/jaeger-collector.Service.yaml
+++ b/base/monitoring/jaeger/jaeger-collector.Service.yaml
@@ -10,18 +10,14 @@ metadata:
     app.kubernetes.io/name: jaeger
 spec:
   ports:
-  - name: jaeger-collector-tchannel
-    port: 14267
+  - name: http-otlp
+    port: 4318
     protocol: TCP
-    targetPort: 14267
-  - name: jaeger-collector-http
-    port: 4321
+    targetPort: http-otlp
+  - name: grpc-otlp
+    port: 4317
     protocol: TCP
-    targetPort: 4321
-  - name: jaeger-collector-grpc
-    port: 4320
-    protocol: TCP
-    targetPort: 4320
+    targetPort: grpc-otlp
   selector:
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: all-in-one

--- a/base/monitoring/jaeger/jaeger.Deployment.yaml
+++ b/base/monitoring/jaeger/jaeger.Deployment.yaml
@@ -31,26 +31,26 @@ spec:
       containers:
         - name: jaeger
           image: index.docker.io/sourcegraph/jaeger-all-in-one:6.2.1106@sha256:c1ee8d613be75032066a9da24f54ebae19eacb63e42338e920abd6383ce168a6
-          args: ["--memory.max-traces=20000", "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json", "--collector.otlp.enabled"]
+          args: ["--config=/etc/jaeger/jaeger-config.yaml"]
           ports:
-            - containerPort: 5775
-              protocol: UDP
-            - containerPort: 6831
-              protocol: UDP
-            - containerPort: 6832
-              protocol: UDP
             - containerPort: 5778
               protocol: TCP
             - containerPort: 16686
+              name: http
               protocol: TCP
-            - containerPort: 4320
+            - containerPort: 4317
+              name: grpc-otlp
               protocol: TCP
-            - containerPort: 4321
+            - containerPort: 4318
+              name: http-otlp
+              protocol: TCP
+            - containerPort: 13133
+              name: health
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: "/"
-              port: 14269
+              path: "/status"
+              port: 13133
             initialDelaySeconds: 5
           resources:
             limits:


### PR DESCRIPTION
## Description

closes PLAT-486

Update manifests to support 2.16 jaeger configurations style

This follows changes to the sourcegraph jaeger base image https://github.com/sourcegraph/sourcegraph/pull/10912

## Test plan

`kubectl kustomize base/monitoring/jaeger`

<details>

```
➜  deploy-sourcegraph-k8s git:(wg/plat/jaeger-2.16) ✗ kubectl kustomize base/monitoring/jaeger
apiVersion: v1
kind: Service
metadata:
  labels:
    app: jaeger
    app.kubernetes.io/component: jaeger
    app.kubernetes.io/name: jaeger
    deploy: sourcegraph
    sourcegraph-resource-requires: no-cluster-admin
  name: jaeger-collector
spec:
  ports:
  - name: http-otlp
    port: 4318
    protocol: TCP
    targetPort: http-otlp
  - name: grpc-otlp
    port: 4317
    protocol: TCP
    targetPort: grpc-otlp
  selector:
    app.kubernetes.io/component: all-in-one
    app.kubernetes.io/name: jaeger
  type: ClusterIP
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: jaeger
    app.kubernetes.io/component: jaeger
    app.kubernetes.io/name: jaeger
    deploy: sourcegraph
    sourcegraph-resource-requires: no-cluster-admin
  name: jaeger-query
spec:
  ports:
  - name: query-http
    port: 16686
    protocol: TCP
    targetPort: 16686
  selector:
    app.kubernetes.io/component: all-in-one
    app.kubernetes.io/name: jaeger
  type: ClusterIP
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: jaeger
    app.kubernetes.io/component: jaeger
    app.kubernetes.io/name: jaeger
    deploy: sourcegraph
    sourcegraph-resource-requires: no-cluster-admin
  name: jaeger
spec:
  replicas: 1
  selector:
    matchLabels:
      app: jaeger
      app.kubernetes.io/component: all-in-one
      app.kubernetes.io/name: jaeger
  strategy:
    type: Recreate
  template:
    metadata:
      annotations:
        prometheus.io/port: "16686"
        prometheus.io/scrape: "true"
      labels:
        app: jaeger
        app.kubernetes.io/component: all-in-one
        app.kubernetes.io/name: jaeger
        deploy: sourcegraph
    spec:
      containers:
      - args:
        - --config=/etc/jaeger/jaeger-config.yaml
        image: index.docker.io/sourcegraph/jaeger-all-in-one:6.2.1106@sha256:c1ee8d613be75032066a9da24f54ebae19eacb63e42338e920abd6383ce168a6
        name: jaeger
        ports:
        - containerPort: 5778
          protocol: TCP
        - containerPort: 16686
          name: http
          protocol: TCP
        - containerPort: 4317
          name: grpc-otlp
          protocol: TCP
        - containerPort: 4318
          name: http-otlp
          protocol: TCP
        - containerPort: 13133
          name: health
          protocol: TCP
        readinessProbe:
          httpGet:
            path: /status
            port: 13133
          initialDelaySeconds: 5
        resources:
          limits:
            cpu: "1"
            memory: 1G
          requests:
            cpu: 500m
            memory: 500M
        securityContext:
          allowPrivilegeEscalation: false
          runAsGroup: 101
          runAsUser: 100
      securityContext:
        fsGroup: 101
        fsGroupChangePolicy: OnRootMismatch
        runAsUser: 100
```

</details>