### PR TITLE
docs: add beta warnings for Kubernetes native executor deployment options

### DIFF
--- a/components/executors/dind/README.md
+++ b/components/executors/dind/README.md
@@ -1,5 +1,10 @@
 # Executors (Docker-in-Docker)
 
+> ⚠️ **Beta:** Docker-in-Docker Kubernetes executors are not recommended for production use.
+> This method requires privileged access to a container runtime daemon. For production workloads,
+> deploy via [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform)
+> or [binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary).
+
 Executors are Sourcegraph’s solution for running untrusted code in a secure and controllable way. For more information on dind executors and how they are used see the Executors [dind documentation](https://docs.sourcegraph.com/admin/executors/deploy_executors_dind)
 
 ## Deploying

--- a/components/executors/k8s/README.md
+++ b/components/executors/k8s/README.md
@@ -1,5 +1,10 @@
 # Executors (Native Kubernetes)
 
+> ⚠️ **Beta:** Native Kubernetes executors are not recommended for production use. This deployment
+> mode has known durability and reliability limitations. For production workloads, deploy using
+> [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform) or the
+> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary).
+
 Executors are Sourcegraph’s solution for running untrusted code in a secure and controllable way. For more information on native kubernetes executors and how they are used see the [Executors documentation](https://docs.sourcegraph.com/admin/executors/deploy_executors_kubernetes)
 
 ## Deploying

--- a/components/executors/k8s/README.md
+++ b/components/executors/k8s/README.md
@@ -1,9 +1,8 @@
 # Executors (Native Kubernetes)
 
-> ⚠️ **Beta:** Native Kubernetes executors are not recommended for production use. This deployment
-> mode has known durability and reliability limitations. For production workloads, deploy using
+> ⚠️ **Beta:** Native Kubernetes executors are in beta. For production workloads, consider deploying using
 > [Terraform](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-terraform) or the
-> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary).
+> [Linux binary](https://docs.sourcegraph.com/self-hosted/executors/deploy-executors-binary) for better long-term support.
 
 Executors are Sourcegraph’s solution for running untrusted code in a secure and controllable way. For more information on native kubernetes executors and how they are used see the [Executors documentation](https://docs.sourcegraph.com/admin/executors/deploy_executors_kubernetes)
 

--- a/examples/executors/README.md
+++ b/examples/executors/README.md
@@ -1,5 +1,8 @@
 # Quickstart overlay for executors
 
+> ⚠️ **Note:** This overlay deploys native Kubernetes executors, which are in beta and not
+> recommended for production use.
+
 This overlay:
 
 - deploys Sourcegraph without monitoring services


### PR DESCRIPTION
closes PLAT-704

Provide a warning to admins or developers reviewing the k8s-native executors deployment type. These changes are intended to prevent further adoption of a deployment type that may not work with future iteractions sourcegraph and executors