### PR TITLE
bug/executors: dind frontend port mismatch

### DIFF
--- a/components/executors/dind/patches/executor.ConfigMap.yaml
+++ b/components/executors/dind/patches/executor.ConfigMap.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: executor-config
-# Refer to https://docs.sourcegraph.com/admin/executors/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
+# Refer to https://sourcegraph.com/docs/self-hosted/executors/deploy-executors-binary#step-2-setup-environment-variables on how to populate these variables
 data:
-  EXECUTOR_FRONTEND_URL: "http://sourcegraph-frontend"
+  EXECUTOR_FRONTEND_URL: "http://sourcegraph-frontend:30080"
   EXECUTOR_MAXIMUM_NUM_JOBS: "8"
   # Used configure which queues Executors will process.
   # Can be "batches" or "codeintel"

--- a/components/executors/k8s/patches/executor.ConfigMap.yaml
+++ b/components/executors/k8s/patches/executor.ConfigMap.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: executor-config
-# Refer to https://docs.sourcegraph.com/admin/executors/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
+# Refer to https://sourcegraph.com/docs/self-hosted/executors/deploy-executors-binary#step-2-setup-environment-variables on how to populate these variables
 data:
-  EXECUTOR_FRONTEND_URL: "http://sourcegraph-frontend"
+  EXECUTOR_FRONTEND_URL: "http://sourcegraph-frontend:30080"
   EXECUTOR_MAXIMUM_NUM_JOBS: "8"
   # Used configure which queues Executors will process.
   # Can be "batches" or "codeintel"

--- a/examples/executors/patches/executor.ConfigMap.yaml
+++ b/examples/executors/patches/executor.ConfigMap.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: executor-config
-# Refer to https://docs.sourcegraph.com/admin/executors/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
+# Refer to https://sourcegraph.com/docs/self-hosted/executors/deploy-executors-binary#step-2-setup-environment-variables on how to populate these variables
 data:
-  EXECUTOR_FRONTEND_URL: "http://sourcegraph-frontend"
+  EXECUTOR_FRONTEND_URL: "http://sourcegraph-frontend:30080"
   EXECUTOR_MAXIMUM_NUM_JOBS: "8"
   # Used configure which queues Executors will process.
   # Can be "batches" or "codeintel"


### PR DESCRIPTION
closes PLAT-757

## Description

The executor Kubernetes deployment configurations contain incorrect or incomplete `frontendUrl` values that cause the executor to silently hang on startup, never connecting to the Sourcegraph instance.

The Sourcegraph frontend Kubernetes service exposes port **30080** in both Helm and Kustomize deployments. The Kustomize executor ConfigMap patches ship with `http://sourcegraph-frontend` (no port), and the Helm dind chart's `values.yaml` provides no guidance on the correct port. Both result in a silent connection failure with no error log.

When a URL omits the port, the HTTP client defaults to port **80** per the HTTP spec. The frontend Kubernetes service does not listen on port 80, so the connection attempt hangs indefinitely — no TCP RST (because the pod IP exists), no application-level error (because the request never reaches the frontend), and no timeout (because Go's default HTTP client has no dial timeout configured). The executor simply blocks forever on its initial connection attempt with no indication of what went wrong.

## How I Identified It

During end-to-end testing of the executor dind Helm chart in a local kind cluster (Apple Silicon / OrbStack with Rosetta), the executor container started successfully but never registered with the Sourcegraph instance. The executor logs showed:

```json
{"Body":"Connecting to Sourcegraph instance","Attributes":{"url":"http://sourcegraph-frontend:3080"}}
```

No follow-up log ever appeared — no "Connected", no error, no timeout. The container sat indefinitely on this line. I confirmed the frontend pod was healthy (1/1 Running, HTTP 200 via port-forward).

Testing connectivity from within the executor pod (via the dind sidecar) revealed the issue:

```bash
$ wget -q -O- --timeout=5 http://sourcegraph-frontend:3080/sign-in
# → download timed out

$ wget -q -O- --timeout=5 http://sourcegraph-frontend:30080/sign-in
# → 200 OK
```

The frontend service definitions confirmed it:

```yaml
# Helm: charts/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
# Kustomize: base/sourcegraph/frontend/sourcegraph-frontend.Service.yaml
spec:
  ports:
    - name: http
      port: 30080        # ← service port (what in-cluster clients must use)
      targetPort: http    # ← maps to container port 3080
```

After changing `frontendUrl` to `http://sourcegraph-frontend:30080`, the executor connected immediately.

Note: The incorrect port (3080) in my test came from my own override file, not from a docs example — the docs don't show any port at all, which is part of the problem.

---

## Checklist

<!--
  Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
  You should not merge a change here without a corresponding change in the other repositories,
  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/CHANGELOG.md)
- [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Kustomiz-specific changes
- [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
- [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
- [ ] Verify all images have a valid tag and SHA256 sum

## Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
