### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/.buildkite/verify-release/go.mod
+++ b/.buildkite/verify-release/go.mod
@@ -1,5 +1,5 @@
 module verify-release
 
-go 1.16
+go 1.26.4
 
 require golang.org/x/mod v0.4.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.21.5
+golang 1.26.4
 yarn 1.22.4
 asdf:kubectl 1.25.9
 fd 7.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sourcegraph/deploy-sourcegraph-k8s
 
-go 1.21.5
+go 1.26.4
 
 require (
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

_Created by Sourcegraph agentic batch change._