### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/.buildkite/verify-release/go.mod
+++ b/.buildkite/verify-release/go.mod
@@ -1,5 +1,5 @@
 module verify-release
 
-go 1.16
+go 1.26.4
 
 require golang.org/x/mod v0.4.2


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)