### PR TITLE
searcher: use debug server readiness endpoint

### DIFF
--- a/base/sourcegraph/searcher/searcher.Service.yaml
+++ b/base/sourcegraph/searcher/searcher.Service.yaml
@@ -13,12 +13,12 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - name: http
+    - name: grpc
       port: 3181
-      targetPort: http
-    - name: debug
+      targetPort: grpc
+    - name: http-debug
       port: 6060
-      targetPort: debug
+      targetPort: http-debug
   selector:
     app: searcher
   type: ClusterIP

--- a/base/sourcegraph/searcher/searcher.StatefulSet.yaml
+++ b/base/sourcegraph/searcher/searcher.StatefulSet.yaml
@@ -50,14 +50,14 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 3181
-              name: http
+              name: grpc
             - containerPort: 6060
-              name: debug
+              name: http-debug
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
-              port: http
+              path: /ready
+              port: http-debug
               scheme: HTTP
             periodSeconds: 5
             timeoutSeconds: 5


### PR DESCRIPTION
- check searcher readiness through the debug server's `/ready` endpoint
- use the canonical `grpc` and `http-debug` named ports for 3181 and 6060
- update the searcher Service target ports to match
- preserve existing readiness thresholds and timing

Mirrors [deploy-sourcegraph-helm#938](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/938).

## Compatibility

Custom consumers that reference the searcher Service ports by their old names (`http` or `debug`) must update to `grpc` or `http-debug`. Numeric ports remain unchanged.