### PR TITLE
fix/docs: Fix spelling errors in the documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,12 +9,12 @@
 <!--
   Kubernetes, both Kustomize and Helm, and Docker Compose MUST be kept in sync.
   You should not merge a change here without a corresponding change in the other repositories,
-  unless it is specific to this deployment type. If uneeded, add link or explanation of why it is not needed here.
+  unless it is specific to this deployment type. If unneeded, add link or explanation of why it is not needed here.
 -->
 
 - [ ] Update [CHANGELOG.md](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/CHANGELOG.md)
 - [ ] Update [K8s Upgrade notes](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
-- [ ] Kustomiz-specific changes
+- [ ] Kustomize-specific changes
 - [ ] Update sister repository: [deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm)
 - [ ] Update sister repository: [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
 - [ ] Verify all images have a valid tag and SHA256 sum

--- a/components/clusters/minikube/README.md
+++ b/components/clusters/minikube/README.md
@@ -1,1 +1,1 @@
-This component deletes resource declarations and storage classnames to enable runnning Sourcegraph on minikube.
+This component deletes resource declarations and storage classnames to enable running Sourcegraph on minikube.

--- a/components/clusters/old-base/README.md
+++ b/components/clusters/old-base/README.md
@@ -4,11 +4,11 @@ This component configure current base cluster using the configurations for the o
 
 It updates and generates resources from the old cluster includes:
 
-    - the monitoring stack and cadvisor
+    - the monitoring stack and cAdvisor
     - searcher and symbols as Deployment
-    - run as root, privilieged
+    - run as root, privileged
     - include RBAC resources
 
-This should only be used to generate old cluster for comparision purpose.
+This should only be used to generate old cluster for comparison purpose.
 
 Check out the `examples/old-cluster` directory to see how this component is used.

--- a/components/network/tls/README.md
+++ b/components/network/tls/README.md
@@ -1,5 +1,5 @@
 # TLS component
 
-For demostration only. We do not recommend storing any keys or secrets remotely.
+For demonstration only. We do not recommend storing any keys or secrets remotely.
 
 DO NOT commit any keys or secrets to public or private repositories.

--- a/components/storage-class/ssd/README.md
+++ b/components/storage-class/ssd/README.md
@@ -1,6 +1,6 @@
 # SSDs
 
-Using local SSDs dramatically speeds up many of Sourcegraph's services. Even if the cluster's default storage class uses SSDs, it's likely network-mounted rather than local. Read your cloud provider's documentation for mouting local SSDs.
+Using local SSDs dramatically speeds up many of Sourcegraph's services. Even if the cluster's default storage class uses SSDs, it's likely network-mounted rather than local. Read your cloud provider's documentation for mounting local SSDs.
 
 - [GCP](https://cloud.google.com/compute/docs/disks/local-ssd)
 - [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html)

--- a/examples/monitoring/privileged/README.md
+++ b/examples/monitoring/privileged/README.md
@@ -1,3 +1,3 @@
 Deploy Sourcegraph monitoring services as root with privileges.
 
-RBAC resouces included.
+RBAC resources included.


### PR DESCRIPTION
Corrections were produced by running [codespell](https://github.com/codespell-project/codespell) over the repository's hand-written Markdown, then reviewing every proposed change in context so that code samples, CLI flags, config keys, YAML keys and values, URLs, identifiers, and quoted output were left untouched. Only spelling is changed; no wording, formatting, or content was otherwise altered.

Files that are generated or vendored are skipped, since fixes there would be overwritten. Where a generated file has a checked-in source, the source is corrected and the generated output is regenerated so the two stay in sync.

[_Created by a Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/1136)