### PR TITLE
gitserver: Add HTTP clone port and health probes

### DIFF
--- a/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
+++ b/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
@@ -41,19 +41,36 @@ spec:
           # gitserver can take a little while to start up. To avoid killing the
           # pod because of a failed liveness probe, we give it 2 minutes to start up.
           startupProbe:
-            tcpSocket:
-              port: rpc
+            httpGet:
+              path: /ready
+              port: http-debug
+              scheme: HTTP
             failureThreshold: 120
             periodSeconds: 1
           livenessProbe:
             initialDelaySeconds: 5
-            tcpSocket:
-              port: rpc
+            httpGet:
+              path: /healthz
+              port: http-debug
+              scheme: HTTP
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-debug
+              scheme: HTTP
+            periodSeconds: 5
             timeoutSeconds: 5
           ports:
             - containerPort: 3178
               protocol: TCP
               name: rpc
+            - containerPort: 3179
+              protocol: TCP
+              name: http-clone
+            - containerPort: 6060
+              protocol: TCP
+              name: http-debug
           resources:
             limits:
               cpu: "4"


### PR DESCRIPTION
Gitserver is gaining a dedicated HTTP clone listener so clone traffic can move away from the h2c gRPC port.

This declares the new `http-clone` port on 3179 and the existing debug server on 6060. It also replaces the TCP checks against the gRPC port with Gitserver's health contract: startup and readiness use `/ready`, while liveness uses `/healthz`.

The headless Service remains unchanged because it provides StatefulSet pod DNS; callers connect directly to pod-qualified Gitserver addresses. `SRC_GIT_SERVERS` remains on the gRPC port, 3178.