### PR TITLE
Remove code intel worker health ports

### DIFF
--- a/base/sourcegraph/precise-code-intel/worker.Deployment.yaml
+++ b/base/sourcegraph/precise-code-intel/worker.Deployment.yaml
@@ -63,8 +63,6 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
           ports:
-            - containerPort: 3188
-              name: http
             - containerPort: 6060
               name: debug
           resources:

--- a/base/sourcegraph/precise-code-intel/worker.Service.yaml
+++ b/base/sourcegraph/precise-code-intel/worker.Service.yaml
@@ -12,9 +12,6 @@ metadata:
   name: precise-code-intel-worker
 spec:
   ports:
-    - name: http
-      port: 3188
-      targetPort: http
     - name: debug
       port: 6060
       targetPort: debug

--- a/base/sourcegraph/syntactic-code-intel/worker.Deployment.yaml
+++ b/base/sourcegraph/syntactic-code-intel/worker.Deployment.yaml
@@ -33,8 +33,6 @@ spec:
               value: blobstore
             - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT
               value: http://blobstore:9000
-            - name: SYNTACTIC_CODE_INTEL_WORKER_ADDR
-              value: ":3188"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -56,8 +54,6 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
           ports:
-            - containerPort: 3188
-              name: http
             - containerPort: 6060
               name: debug
           resources:

--- a/base/sourcegraph/syntactic-code-intel/worker.Service.yaml
+++ b/base/sourcegraph/syntactic-code-intel/worker.Service.yaml
@@ -12,9 +12,6 @@ metadata:
   name: syntactic-code-intel
 spec:
   ports:
-    - name: http
-      port: 3188
-      targetPort: http
     - name: debug
       port: 6060
       targetPort: debug


### PR DESCRIPTION
The precise and syntactic code intel workers already serve liveness, readiness, and Prometheus metrics from their debugservers on port 6060. Remove their redundant application ports from the Deployments and Services.