### PR TITLE
Configure shared object storage consumers

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -22,8 +22,11 @@ See the [Sourcegraph Kustomize docs](https://docs.sourcegraph.com/admin/deploy/k
 
 ## Shared object storage
 
-The base configures the bundled blobstore for shared Sourcegraph uploads. The
-`sourcegraph-upload` ConfigMap is consumed by exactly `sourcegraph-frontend`,
+Sourcegraph requires access to an object storage backend. [Learn more](https://sourcegraph.com/docs/self-hosted/external-services/object-storage#sourcegraph-bucket).
+
+While we highly recommend using S3 or GCS for any production workloads, to get you
+started quickly the base configures a bundled blobstore.
+The `sourcegraph-upload` ConfigMap is consumed by `sourcegraph-frontend`,
 `worker`, `precise-code-intel-worker`, `syntactic-code-intel`, `gitserver`, and
 `searcher`.
 

--- a/base/README.md
+++ b/base/README.md
@@ -19,3 +19,54 @@ If using cluster roles and cluster rolebinding RBAC is not feasible, you may cho
 ## Deploy Sourcegraph
 
 See the [Sourcegraph Kustomize docs](https://docs.sourcegraph.com/admin/deploy/kubernetes/kustomize) for the latested instructions.
+
+## Shared object storage
+
+The base configures the bundled blobstore for shared Sourcegraph uploads. The
+`sourcegraph-upload` ConfigMap is consumed by exactly `sourcegraph-frontend`,
+`worker`, `precise-code-intel-worker`, `gitserver`, and `searcher`.
+
+To use external S3 or GCS storage, patch that ConfigMap in your overlay with
+the applicable `SOURCEGRAPH_UPLOAD_*` settings. Put static credentials in a
+Secret rather than the ConfigMap, and add that Secret with `envFrom` to each
+of the five workloads. For example:
+
+```yaml
+patches:
+  - target:
+      kind: ConfigMap
+      name: sourcegraph-upload
+    patch: |-
+      - op: replace
+        path: /data/SOURCEGRAPH_UPLOAD_BACKEND
+        value: S3
+      - op: add
+        path: /data/SOURCEGRAPH_UPLOAD_BUCKET
+        value: my-sourcegraph-uploads
+      - op: add
+        path: /data/SOURCEGRAPH_UPLOAD_AWS_REGION
+        value: us-east-1
+  - target:
+      kind: Deployment
+      name: sourcegraph-frontend|worker|precise-code-intel-worker
+    patch: &uploadCredentials |-
+      - op: add
+        path: /spec/template/spec/containers/0/envFrom/-
+        value:
+          secretRef:
+            name: sourcegraph-upload-credentials
+  - target:
+      kind: StatefulSet
+      name: gitserver|searcher
+    patch: *uploadCredentials
+```
+
+Create `sourcegraph-upload-credentials` with keys such as
+`SOURCEGRAPH_UPLOAD_AWS_ACCESS_KEY_ID` and
+`SOURCEGRAPH_UPLOAD_AWS_SECRET_ACCESS_KEY`. Alternatively, configure the pod
+service accounts for your cloud provider's workload identity and set
+`SOURCEGRAPH_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS: "true"` for S3. For GCS,
+set `SOURCEGRAPH_UPLOAD_GCP_PROJECT_ID`; workload identity uses the pod service
+account, while a key can be supplied with
+`SOURCEGRAPH_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT` in the
+credentials Secret.

--- a/base/README.md
+++ b/base/README.md
@@ -24,12 +24,13 @@ See the [Sourcegraph Kustomize docs](https://docs.sourcegraph.com/admin/deploy/k
 
 The base configures the bundled blobstore for shared Sourcegraph uploads. The
 `sourcegraph-upload` ConfigMap is consumed by exactly `sourcegraph-frontend`,
-`worker`, `precise-code-intel-worker`, `gitserver`, and `searcher`.
+`worker`, `precise-code-intel-worker`, `syntactic-code-intel`, `gitserver`, and
+`searcher`.
 
 To use external S3 or GCS storage, patch that ConfigMap in your overlay with
 the applicable `SOURCEGRAPH_UPLOAD_*` settings. Put static credentials in a
 Secret rather than the ConfigMap, and add that Secret with `envFrom` to each
-of the five workloads. For example:
+of the six workloads. For example:
 
 ```yaml
 patches:
@@ -48,7 +49,7 @@ patches:
         value: us-east-1
   - target:
       kind: Deployment
-      name: sourcegraph-frontend|worker|precise-code-intel-worker
+      name: sourcegraph-frontend|worker|precise-code-intel-worker|syntactic-code-intel
     patch: &uploadCredentials |-
       - op: add
         path: /spec/template/spec/containers/0/envFrom/-

--- a/base/sourcegraph/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/sourcegraph/frontend/sourcegraph-frontend.Deployment.yaml
@@ -54,6 +54,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: sourcegraph-frontend-env
+            - configMapRef:
+                name: sourcegraph-upload
           # OTEL_AGENT_HOST must be defined before OTEL_EXPORTER_OTLP_ENDPOINT to substitute the node IP on which the DaemonSet pod instance runs in the latter variable
           env:
             - name: OTEL_AGENT_HOST

--- a/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
+++ b/base/sourcegraph/gitserver/gitserver.StatefulSet.yaml
@@ -27,6 +27,9 @@ spec:
       containers:
         - name: gitserver
           args: ["run"]
+          envFrom:
+            - configMapRef:
+                name: sourcegraph-upload
           env:
             # OTEL_AGENT_HOST must be defined before OTEL_EXPORTER_OTLP_ENDPOINT to substitute the node IP on which the DaemonSet pod instance runs in the latter variable
             - name: OTEL_AGENT_HOST

--- a/base/sourcegraph/kustomization.yaml
+++ b/base/sourcegraph/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - sourcegraph-upload.ConfigMap.yaml
   - blobstore
   - codeinsights-db
   - codeintel-db

--- a/base/sourcegraph/precise-code-intel/worker.Deployment.yaml
+++ b/base/sourcegraph/precise-code-intel/worker.Deployment.yaml
@@ -28,6 +28,9 @@ spec:
     spec:
       containers:
         - name: precise-code-intel-worker
+          envFrom:
+            - configMapRef:
+                name: sourcegraph-upload
           env:
             - name: PRECISE_CODE_INTEL_UPLOAD_BACKEND
               value: blobstore

--- a/base/sourcegraph/searcher/searcher.StatefulSet.yaml
+++ b/base/sourcegraph/searcher/searcher.StatefulSet.yaml
@@ -30,6 +30,9 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: searcher
+          envFrom:
+            - configMapRef:
+                name: sourcegraph-upload
           env:
             - name: SEARCHER_CACHE_SIZE_MB
               value: "25000"

--- a/base/sourcegraph/sourcegraph-upload.ConfigMap.yaml
+++ b/base/sourcegraph/sourcegraph-upload.ConfigMap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sourcegraph-upload
+  labels:
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+data:
+  SOURCEGRAPH_UPLOAD_BACKEND: Blobstore
+  SOURCEGRAPH_UPLOAD_AWS_ENDPOINT: http://blobstore:9000

--- a/base/sourcegraph/sourcegraph-upload.ConfigMap.yaml
+++ b/base/sourcegraph/sourcegraph-upload.ConfigMap.yaml
@@ -6,5 +6,5 @@ metadata:
     deploy: sourcegraph
     sourcegraph-resource-requires: no-cluster-admin
 data:
-  SOURCEGRAPH_UPLOAD_BACKEND: Blobstore
+  SOURCEGRAPH_UPLOAD_BACKEND: blobstore
   SOURCEGRAPH_UPLOAD_AWS_ENDPOINT: http://blobstore:9000

--- a/base/sourcegraph/syntactic-code-intel/worker.Deployment.yaml
+++ b/base/sourcegraph/syntactic-code-intel/worker.Deployment.yaml
@@ -28,6 +28,9 @@ spec:
     spec:
       containers:
         - name: syntactic-code-intel
+          envFrom:
+            - configMapRef:
+                name: sourcegraph-upload
           env:
             - name: PRECISE_CODE_INTEL_UPLOAD_BACKEND
               value: blobstore

--- a/base/sourcegraph/worker/worker.Deployment.yaml
+++ b/base/sourcegraph/worker/worker.Deployment.yaml
@@ -32,6 +32,9 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: worker
+          envFrom:
+            - configMapRef:
+                name: sourcegraph-upload
           env:
             - name: PRECISE_CODE_INTEL_UPLOAD_BACKEND
               value: blobstore


### PR DESCRIPTION
Shared object storage is now used beyond the legacy precise Code Intel upload path, but the Kustomize deployment did not provide the shared `SOURCEGRAPH_UPLOAD_*` configuration to every consumer. This adds documentation and config for it.